### PR TITLE
Refactor: extract `specs` from `main` to a separate package.

### DIFF
--- a/cmd/wksctl/addon-build.go
+++ b/cmd/wksctl/addon-build.go
@@ -66,7 +66,7 @@ func makeParams(input []string) (map[string]string, error) {
 func addonBuildRun(cmd *cobra.Command, args []string) {
 	opts := &addonBuildOptions
 
-	addon, err := GetAddon(args[0])
+	addon, err := addons.Get(args[0])
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/wksctl/addon-build.go
+++ b/cmd/wksctl/addon-build.go
@@ -7,9 +7,8 @@ import (
 	"strings"
 
 	log "github.com/sirupsen/logrus"
-	"github.com/weaveworks/wksctl/pkg/addons"
-
 	"github.com/spf13/cobra"
+	"github.com/weaveworks/wksctl/pkg/addons"
 )
 
 var addonBuildCmd = &cobra.Command{

--- a/cmd/wksctl/addon-show.go
+++ b/cmd/wksctl/addon-show.go
@@ -7,8 +7,9 @@ import (
 	"text/tabwriter"
 
 	log "github.com/sirupsen/logrus"
-
 	"github.com/spf13/cobra"
+
+	"github.com/weaveworks/wksctl/pkg/addons"
 )
 
 var addonShowCmd = &cobra.Command{
@@ -31,7 +32,7 @@ func addonShowArgs(cmd *cobra.Command, args []string) error {
 }
 
 func addonShowRun(cmd *cobra.Command, args []string) {
-	addon, err := GetAddon(args[0])
+	addon, err := addons.Get(args[0])
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/wksctl/addon-show.go
+++ b/cmd/wksctl/addon-show.go
@@ -8,7 +8,6 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-
 	"github.com/weaveworks/wksctl/pkg/addons"
 )
 

--- a/cmd/wksctl/addon.go
+++ b/cmd/wksctl/addon.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"github.com/spf13/cobra"
-
 	"github.com/weaveworks/wksctl/pkg/addons"
 )
 

--- a/cmd/wksctl/addon.go
+++ b/cmd/wksctl/addon.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"github.com/spf13/cobra"
+
 	"github.com/weaveworks/wksctl/pkg/addons"
 )
 
@@ -22,11 +23,6 @@ func ListAddons() []addons.Addon {
 	}
 
 	return results
-}
-
-// GetAddon looks up for the Addon object by name
-func GetAddon(shortName string) (addons.Addon, error) {
-	return addons.Get(shortName)
 }
 
 func init() {

--- a/cmd/wksctl/apply.go
+++ b/cmd/wksctl/apply.go
@@ -217,9 +217,25 @@ func initiateCluster(clusterManifestPath, machinesManifestPath string, closer fu
 		ImageRepository:      sp.ClusterSpec.ImageRepository,
 		ExternalLoadBalancer: sp.ClusterSpec.APIServer.ExternalLoadBalancer,
 		AdditionalSANs:       sp.ClusterSpec.APIServer.AdditionalSANs,
-		Namespace:            sp.GetClusterNamespace(),
+		Namespace:            getClusterNamespace(),
 	}); err != nil {
 		log.Fatalf("Failed to set up seed node (%s): %v",
 			sp.GetMasterPublicAddress(), err)
 	}
+}
+
+func getClusterNamespace() string {
+	if applyOptions.useManifestNamespace {
+		return ""
+	}
+	return firstNonDefaultOrDefault(applyOptions.namespace, kubeconfigOptions.namespace)
+}
+
+func firstNonDefaultOrDefault(nses ...string) string {
+	for _, ns := range nses {
+		if ns != manifest.DefaultNamespace {
+			return ns
+		}
+	}
+	return manifest.DefaultNamespace
 }

--- a/cmd/wksctl/apply.go
+++ b/cmd/wksctl/apply.go
@@ -188,6 +188,11 @@ func initiateCluster(clusterManifestPath, machinesManifestPath string, closer fu
 		configDir = filepath.Dir(clusterManifestPath)
 	}
 
+	ns := ""
+	if !applyOptions.useManifestNamespace {
+		ns = applyOptions.namespace
+	}
+
 	// TODO(damien): Transform the controller image into an addon.
 	controllerImage, err := addons.UpdateImage(applyOptions.controllerImage, sp.ClusterSpec.ImageRepository)
 	if err != nil {
@@ -217,25 +222,9 @@ func initiateCluster(clusterManifestPath, machinesManifestPath string, closer fu
 		ImageRepository:      sp.ClusterSpec.ImageRepository,
 		ExternalLoadBalancer: sp.ClusterSpec.APIServer.ExternalLoadBalancer,
 		AdditionalSANs:       sp.ClusterSpec.APIServer.AdditionalSANs,
-		Namespace:            getClusterNamespace(),
+		Namespace:            ns,
 	}); err != nil {
 		log.Fatalf("Failed to set up seed node (%s): %v",
 			sp.GetMasterPublicAddress(), err)
 	}
-}
-
-func getClusterNamespace() string {
-	if applyOptions.useManifestNamespace {
-		return ""
-	}
-	return firstNonDefaultOrDefault(applyOptions.namespace, kubeconfigOptions.namespace)
-}
-
-func firstNonDefaultOrDefault(nses ...string) string {
-	for _, ns := range nses {
-		if ns != manifest.DefaultNamespace {
-			return ns
-		}
-	}
-	return manifest.DefaultNamespace
 }

--- a/cmd/wksctl/apply.go
+++ b/cmd/wksctl/apply.go
@@ -6,10 +6,9 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/weaveworks/wksctl/pkg/addons"
-
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"github.com/weaveworks/wksctl/pkg/addons"
 	"github.com/weaveworks/wksctl/pkg/apis/wksprovider/machine/config"
 	wksos "github.com/weaveworks/wksctl/pkg/apis/wksprovider/machine/os"
 	"github.com/weaveworks/wksctl/pkg/specs"

--- a/cmd/wksctl/apply_addons.go
+++ b/cmd/wksctl/apply_addons.go
@@ -59,7 +59,7 @@ func applyAddonsUsingConfig(sp *specs.Specs, basePath, kubeconfig string) error 
 		log.Debugf("applying addon '%s'", addonDesc.Name)
 
 		// Generate the addon manifest.
-		addon, err := GetAddon(addonDesc.Name)
+		addon, err := addons.Get(addonDesc.Name)
 		if err != nil {
 			return err
 		}

--- a/cmd/wksctl/apply_addons.go
+++ b/cmd/wksctl/apply_addons.go
@@ -9,11 +9,10 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"github.com/weaveworks/launcher/pkg/kubectl"
 	"github.com/weaveworks/wksctl/pkg/addons"
 	"github.com/weaveworks/wksctl/pkg/kubernetes/config"
 	"github.com/weaveworks/wksctl/pkg/specs"
-
-	"github.com/weaveworks/launcher/pkg/kubectl"
 	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 )
 

--- a/cmd/wksctl/kubeconfig.go
+++ b/cmd/wksctl/kubeconfig.go
@@ -63,7 +63,7 @@ func init() {
 
 func configPath(sp *specs.Specs, wksHome string) string {
 	clusterName := sp.GetClusterName()
-	configDir := path.WKSResourcePath(wksHome, sp.GetClusterNamespace(), clusterName)
+	configDir := path.WKSResourcePath(wksHome, getClusterNamespace(), clusterName)
 	return filepath.Join(configDir, "kubeconfig")
 }
 

--- a/cmd/wksctl/kubeconfig.go
+++ b/cmd/wksctl/kubeconfig.go
@@ -63,7 +63,7 @@ func init() {
 
 func configPath(sp *specs.Specs, wksHome string) string {
 	clusterName := sp.GetClusterName()
-	configDir := path.WKSResourcePath(wksHome, getClusterNamespace(), clusterName)
+	configDir := path.WKSResourcePath(wksHome, kubeconfigOptions.namespace, clusterName)
 	return filepath.Join(configDir, "kubeconfig")
 }
 

--- a/cmd/wksctl/kubeconfig.go
+++ b/cmd/wksctl/kubeconfig.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/weaveworks/wksctl/pkg/kubernetes/config"
 	"github.com/weaveworks/wksctl/pkg/plan/runners/sudo"
+	"github.com/weaveworks/wksctl/pkg/specs"
 	"github.com/weaveworks/wksctl/pkg/utilities/manifest"
 	"github.com/weaveworks/wksctl/pkg/utilities/path"
 )
@@ -60,15 +61,15 @@ func init() {
 	rootCmd.AddCommand(kubeconfigCmd)
 }
 
-func configPath(specs *specs, wksHome string) string {
-	clusterName := specs.getClusterName()
-	configDir := path.WKSResourcePath(wksHome, specs.getClusterNamespace(), clusterName)
+func configPath(sp *specs.Specs, wksHome string) string {
+	clusterName := sp.GetClusterName()
+	configDir := path.WKSResourcePath(wksHome, sp.GetClusterNamespace(), clusterName)
 	return filepath.Join(configDir, "kubeconfig")
 }
 
 // TODO this should be refactored into a common place - i.e. pkg/cluster
-func generateConfig(specs *specs, configPath string) string {
-	sshClient, err := specs.getSSHClient(options.verbose)
+func generateConfig(sp *specs.Specs, configPath string) string {
+	sshClient, err := sp.GetSSHClient(options.verbose)
 	if err != nil {
 		log.Fatal("Failed to create SSH client: ", err)
 	}
@@ -80,9 +81,9 @@ func generateConfig(specs *specs, configPath string) string {
 		log.Fatalf("Failed to retrieve Kubernetes configuration: %v", err)
 	}
 
-	endpoint := specs.getMasterPublicAddress()
-	if specs.clusterSpec.APIServer.ExternalLoadBalancer != "" {
-		endpoint = specs.clusterSpec.APIServer.ExternalLoadBalancer
+	endpoint := sp.GetMasterPublicAddress()
+	if sp.ClusterSpec.APIServer.ExternalLoadBalancer != "" {
+		endpoint = sp.ClusterSpec.APIServer.ExternalLoadBalancer
 	}
 
 	configStr, err = config.Sanitize(configStr, config.Params{
@@ -105,20 +106,20 @@ func kubeconfigRun(cmd *cobra.Command, args []string) {
 	if err != nil {
 		log.Fatalf("Failed to create WKS home directory: %v", err)
 	}
-	specs := getSpecs(clusterManifestPath, machinesManifestPath)
+	sp := specs.NewFromPaths(clusterManifestPath, machinesManifestPath)
 
-	configPath := configPath(specs, wksHome)
+	configPath := configPath(sp, wksHome)
 
 	_, err = path.CreateDirectory(filepath.Dir(configPath))
 	if err != nil {
 		log.Fatalf("Failed to create configuration directory: %v", err)
 	}
 
-	configStr := generateConfig(specs, configPath)
+	configStr := generateConfig(sp, configPath)
 
 	err = ioutil.WriteFile(configPath, []byte(configStr), 0644)
 	if err != nil {
 		log.Fatalf("Failed to write Kubernetes configuration locally: %v", err)
 	}
-	fmt.Printf("To use kubectl with the %s cluster, enter:\n$ export KUBECONFIG=%s\n", specs.getClusterName(), configPath)
+	fmt.Printf("To use kubectl with the %s cluster, enter:\n$ export KUBECONFIG=%s\n", sp.GetClusterName(), configPath)
 }

--- a/cmd/wksctl/registry.go
+++ b/cmd/wksctl/registry.go
@@ -10,6 +10,7 @@ import (
 	"github.com/weaveworks/wksctl/pkg/kubernetes"
 	"github.com/weaveworks/wksctl/pkg/quay"
 	"github.com/weaveworks/wksctl/pkg/registry"
+	"github.com/weaveworks/wksctl/pkg/utilities"
 	v "github.com/weaveworks/wksctl/pkg/utilities/version"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
@@ -103,7 +104,7 @@ func kubernetesVersionsRange() string {
 func extractKubernetesVersionFromMachines(machinesManifestPath string) (string, error) {
 	errorsHandler := func(machines []*clusterv1.Machine, errors field.ErrorList) ([]*clusterv1.Machine, error) {
 		if len(errors) > 0 {
-			printValidationErrors(errors)
+			utilities.PrintErrors(errors)
 			return nil, apierrors.InvalidMachineConfiguration("%s failed validation", machinesManifestPath)
 		}
 		return machines, nil

--- a/pkg/specs/specs.go
+++ b/pkg/specs/specs.go
@@ -10,6 +10,7 @@ import (
 	baremetalspecv1 "github.com/weaveworks/wksctl/pkg/baremetalproviderspec/v1alpha1"
 	"github.com/weaveworks/wksctl/pkg/cluster/machine"
 	"github.com/weaveworks/wksctl/pkg/plan/runners/ssh"
+	"github.com/weaveworks/wksctl/pkg/utilities"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 	apierrors "sigs.k8s.io/cluster-api/pkg/errors"
@@ -84,14 +85,14 @@ func parseManifests(clusterManifestPath, machinesManifestPath string) (*clusterv
 
 	validationErrors := validateCluster(cluster, clusterManifestPath)
 	if len(validationErrors) > 0 {
-		printValidationErrors(validationErrors)
+		utilities.PrintErrors(validationErrors)
 		return nil, nil, apierrors.InvalidMachineConfiguration(
 			"%s failed validation, use --skip-validation to force the operation", clusterManifestPath)
 	}
 
 	errorsHandler := func(machines []*clusterv1.Machine, errors field.ErrorList) ([]*clusterv1.Machine, error) {
 		if len(errors) > 0 {
-			printValidationErrors(errors)
+			utilities.PrintErrors(validationErrors)
 			return nil, apierrors.InvalidMachineConfiguration(
 				"%s failed validation, use --skip-validation to force the operation", machinesManifestPath)
 		}

--- a/pkg/specs/specs.go
+++ b/pkg/specs/specs.go
@@ -10,7 +10,6 @@ import (
 	baremetalspecv1 "github.com/weaveworks/wksctl/pkg/baremetalproviderspec/v1alpha1"
 	"github.com/weaveworks/wksctl/pkg/cluster/machine"
 	"github.com/weaveworks/wksctl/pkg/plan/runners/ssh"
-	"github.com/weaveworks/wksctl/pkg/utilities/manifest"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 	apierrors "sigs.k8s.io/cluster-api/pkg/errors"
@@ -140,22 +139,6 @@ func (s *Specs) GetSSHKeyPath() string {
 
 func (s *Specs) GetClusterName() string {
 	return s.cluster.ObjectMeta.Name
-}
-
-func (s *Specs) GetClusterNamespace() string {
-	if applyOptions.useManifestNamespace {
-		return ""
-	}
-	return firstNonDefaultOrDefault(applyOptions.namespace, kubeconfigOptions.namespace)
-}
-
-func firstNonDefaultOrDefault(nses ...string) string {
-	for _, ns := range nses {
-		if ns != manifest.DefaultNamespace {
-			return ns
-		}
-	}
-	return manifest.DefaultNamespace
 }
 
 func (s *Specs) GetMasterPublicAddress() string {

--- a/pkg/specs/validation.go
+++ b/pkg/specs/validation.go
@@ -1,4 +1,4 @@
-package main
+package specs
 
 import (
 	"fmt"

--- a/pkg/specs/validation.go
+++ b/pkg/specs/validation.go
@@ -234,7 +234,7 @@ func validateAddons(cluster *clusterv1.Cluster, manifestPath string) field.Error
 
 	// Validate addons and their parameters.
 	for i, addonDesc := range spec.Addons {
-		addon, err := GetAddon(addonDesc.Name)
+		addon, err := addons.Get(addonDesc.Name)
 		if err != nil {
 			return field.ErrorList{
 				field.Invalid(addonPath(i, addonDesc.Name), addonDesc.Name, err.Error()),

--- a/pkg/specs/validation.go
+++ b/pkg/specs/validation.go
@@ -3,7 +3,6 @@ package specs
 import (
 	"fmt"
 	"net"
-	//"net/url"
 	"os"
 	"path/filepath"
 	"strings"

--- a/pkg/specs/validation.go
+++ b/pkg/specs/validation.go
@@ -19,12 +19,6 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 )
 
-func printValidationErrors(errors field.ErrorList) {
-	for _, e := range errors {
-		log.Errorf("%v\n", e)
-	}
-}
-
 func clusterPath(args ...string) *field.Path {
 	return field.NewPath("cluster", args...)
 }

--- a/pkg/specs/validation_test.go
+++ b/pkg/specs/validation_test.go
@@ -1,4 +1,4 @@
-package main
+package specs
 
 import (
 	"os"

--- a/pkg/specs/validation_test.go
+++ b/pkg/specs/validation_test.go
@@ -2,10 +2,9 @@ package specs
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
-
-	"path/filepath"
 
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/util/validation/field"

--- a/pkg/utilities/print.go
+++ b/pkg/utilities/print.go
@@ -1,0 +1,12 @@
+package utilities
+
+import (
+	log "github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+func PrintErrors(errors field.ErrorList) {
+	for _, e := range errors {
+		log.Errorf("%v\n", e)
+	}
+}


### PR DESCRIPTION
Part of #33. I suggest reviewing commit by commit.

This PR:
- extracts the `specs` logic shared by commands into a separate package (to facilitate separation of commands into individual packages and making them available as a Go API - see #33),
- makes several local cleanups that were necessary for the above:
  - removes the unnecessary `GetAddon()` that was just a no-op cleat to `addons.Get()` and broke the now-introduced package boundary,
  - extracts `GetClusterNamespace()` from `specs` because it's unrelated to `specs`:
    - `GetClusterNamespace()` accessed options of commands other than the command being run - this PR removes that issue by removing `GetClusterNamespace()` and refactoring the logic to depend only on valid command params,
  - renames `printValidationErrors()` to `PrintErrors()` and moves it into the `utilities` package. This was necessary for the new package structure.