### PR TITLE
init: Don't add quotes to arguments

### DIFF
--- a/cmd/wksctl/init.go
+++ b/cmd/wksctl/init.go
@@ -105,7 +105,7 @@ func and(checks ...func([]byte) bool) func([]byte) bool {
 }
 
 func updatedArg(item string) []byte {
-	return []byte(fmt.Sprintf("$1=%q", item))
+	return []byte(fmt.Sprintf("$1=%s", item))
 }
 
 func updateControllerManifests(contents []byte, options initOptionType) ([]byte, error) {

--- a/cmd/wksctl/init_test.go
+++ b/cmd/wksctl/init_test.go
@@ -171,7 +171,7 @@ func TestFluxTranslate(t *testing.T) {
 			gitPath:   "eightfold",
 		})
 	assert.NoError(t, err)
-	assert.Equal(t, res, []byte(fluxOutputs))
+	assert.Equal(t, string(res), fluxOutputs)
 }
 
 const controllerInputs = `
@@ -293,5 +293,5 @@ func TestControllerTranslate(t *testing.T) {
 			version: "version1.2.3",
 		})
 	assert.NoError(t, err)
-	assert.Equal(t, res, []byte(controllerOutputs))
+	assert.Equal(t, string(res), controllerOutputs)
 }

--- a/cmd/wksctl/init_test.go
+++ b/cmd/wksctl/init_test.go
@@ -122,10 +122,10 @@ items:
         containers:
         - args:
           - --ssh-keygen-dir=/var/fluxd/keygen
-          - --git-url="git@github.com:weaveworks/foo.bar"
-          - --git-branch="rickey"
+          - --git-url=git@github.com:weaveworks/foo.bar
+          - --git-branch=rickey
           - --git-poll-interval=30s
-          - --git-path="eightfold"
+          - --git-path=eightfold
           - --memcached-hostname=memcached.weavek8sops.svc.cluster.local
           - --memcached-service=memcached
           - --listen-metrics=:3031

--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,6 @@ require (
 	golang.org/x/crypto v0.0.0-20190617133340-57b3e21c3d56
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.0.1 // indirect
-	google.golang.org/appengine v1.4.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/oleiade/reflections.v1 v1.0.0
 	gopkg.in/src-d/go-git.v4 v4.10.0


### PR DESCRIPTION
Quotes are integral part of the flux argv[i] argument as it's directly used by
one of the exec variants and not interpreted by a shell beforehand. Don't add
it! This was leading to errors later on in flux:

```
git repo not ready: git clone --mirror: fatal: protocol '\"https' is not supported
```