### PR TITLE
specs, GetRemoteKubeconfig: error handling fixes; export more symbols

### DIFF
--- a/cmd/wksctl/kubeconfig/kubeconfig.go
+++ b/cmd/wksctl/kubeconfig/kubeconfig.go
@@ -80,16 +80,16 @@ func kubeconfigRun(cmd *cobra.Command, args []string) error {
 	}
 	sp := specs.NewFromPaths(clusterManifestPath, machinesManifestPath)
 
+	configStr, err := config.GetRemoteKubeconfig(sp, kubeconfigOptions.verbose, kubeconfigOptions.skipTLSVerify)
+	if err != nil {
+		return errors.Wrapf(err, "GetRemoteKubeconfig")
+	}
+
 	configPath := path.Kubeconfig(wksHome, kubeconfigOptions.namespace, sp.GetClusterName())
 
 	_, err = path.CreateDirectory(filepath.Dir(configPath))
 	if err != nil {
 		return errors.Wrapf(err, "failed to create configuration directory")
-	}
-
-	configStr, err := config.GetRemoteKubeconfig(sp, configPath, kubeconfigOptions.verbose, kubeconfigOptions.skipTLSVerify)
-	if err != nil {
-		return nil
 	}
 
 	err = ioutil.WriteFile(configPath, []byte(configStr), 0644)

--- a/pkg/kubernetes/config/kubeconfig.go
+++ b/pkg/kubernetes/config/kubeconfig.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"fmt"
-	log "github.com/sirupsen/logrus"
 	"net/url"
 	"regexp"
 
@@ -94,12 +93,8 @@ func GetRemoteKubeconfig(sp *specs.Specs, configPath string, verbose, skipTLSVer
 		endpoint = sp.ClusterSpec.APIServer.ExternalLoadBalancer
 	}
 
-	configStr, err = Sanitize(configStr, Params{
+	return Sanitize(configStr, Params{
 		APIServerExternalEndpoint: endpoint,
 		SkipTLSVerify:             skipTLSVerify,
 	})
-	if err != nil {
-		log.Fatal(err)
-	}
-	return configStr, nil
 }

--- a/pkg/kubernetes/config/kubeconfig.go
+++ b/pkg/kubernetes/config/kubeconfig.go
@@ -75,7 +75,7 @@ func Sanitize(configStr string, params Params) (string, error) {
 	return configStr, nil
 }
 
-func GetRemoteKubeconfig(sp *specs.Specs, configPath string, verbose, skipTLSVerify bool) (string, error) {
+func GetRemoteKubeconfig(sp *specs.Specs, verbose, skipTLSVerify bool) (string, error) {
 	sshClient, err := sp.GetSSHClient(verbose)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to create SSH client: ")


### PR DESCRIPTION
Part of #33.

- Fixes error handling in `GetRemoteKubeconfig` - removes a `log.Fatalf` where we should return an error
- Fixes error handling in `Specs` - closure should use its argument, and not  a captured variable
- Implements `GetMasterCount` and `GetMachineCount` in `Specs`