### PR TITLE
refactor, bugfix: fix manifest path handling; refactor manifests.Get; small style fixes

### DIFF
--- a/cmd/wksctl/apply/apply.go
+++ b/cmd/wksctl/apply/apply.go
@@ -80,11 +80,12 @@ func (a *Applier) Apply() error {
 	if err != nil {
 		return err
 	}
-	return a.initiateCluster(cpath, mpath, closer)
+	defer closer()
+
+	return a.initiateCluster(cpath, mpath)
 }
 
-func (a *Applier) initiateCluster(clusterManifestPath, machinesManifestPath string, closer func()) error {
-	defer closer()
+func (a *Applier) initiateCluster(clusterManifestPath, machinesManifestPath string) error {
 	sp := specs.NewFromPaths(clusterManifestPath, machinesManifestPath)
 	sshClient, err := sp.GetSSHClient(a.Params.verbose)
 	if err != nil {

--- a/cmd/wksctl/apply/apply.go
+++ b/cmd/wksctl/apply/apply.go
@@ -68,6 +68,8 @@ type Applier struct {
 func (a *Applier) Apply() error {
 	var clusterPath, machinesPath string
 
+	// TODO: deduplicate clusterPath/machinesPath evaluation between here and other places
+	// https://github.com/weaveworks/wksctl/issues/58
 	if a.Params.gitURL == "" {
 		// Cluster and Machine manifests come from the local filesystem.
 		clusterPath, machinesPath = a.Params.clusterManifestPath, a.Params.machinesManifestPath

--- a/cmd/wksctl/apply/apply.go
+++ b/cmd/wksctl/apply/apply.go
@@ -66,11 +66,11 @@ type Applier struct {
 }
 
 func (a *Applier) Apply() error {
-	var cpath, mpath string
+	var clusterPath, machinesPath string
 
 	if a.Params.gitURL == "" {
 		// Cluster and Machine manifests come from the local filesystem.
-		cpath, mpath = a.Params.clusterManifestPath, a.Params.machinesManifestPath
+		clusterPath, machinesPath = a.Params.clusterManifestPath, a.Params.machinesManifestPath
 	} else {
 		// Cluster and Machine manifests come from a Git repo that we'll clone for the duration of this command.
 		repo, err := manifests.CloneClusterAPIRepo(a.Params.gitURL, a.Params.gitBranch, a.Params.gitDeployKeyPath, a.Params.gitPath)
@@ -79,15 +79,15 @@ func (a *Applier) Apply() error {
 		}
 		defer repo.Close()
 
-		if cpath, err = repo.ClusterManifestPath(); err != nil {
+		if clusterPath, err = repo.ClusterManifestPath(); err != nil {
 			return errors.Wrap(err, "ClusterManifestPath")
 		}
-		if mpath, err = repo.MachinesManifestPath(); err != nil {
+		if machinesPath, err = repo.MachinesManifestPath(); err != nil {
 			return errors.Wrap(err, "MachinesManifestPath")
 		}
 	}
 
-	return a.initiateCluster(cpath, mpath)
+	return a.initiateCluster(clusterPath, machinesPath)
 }
 
 func (a *Applier) initiateCluster(clusterManifestPath, machinesManifestPath string) error {

--- a/cmd/wksctl/apply/apply.go
+++ b/cmd/wksctl/apply/apply.go
@@ -69,7 +69,7 @@ func (a *Applier) Apply() error {
 	var cpath, mpath string
 
 	if a.Params.gitURL == "" {
-		// Cluster and Manifests come from the local filesystem.
+		// Cluster and Machine manifests come from the local filesystem.
 		cpath, mpath = a.Params.clusterManifestPath, a.Params.machinesManifestPath
 	} else {
 		// Cluster and Machine manifests come from a Git repo that we'll clone for the duration of this command.

--- a/cmd/wksctl/apply/apply.go
+++ b/cmd/wksctl/apply/apply.go
@@ -66,11 +66,6 @@ type Applier struct {
 }
 
 func (a *Applier) Apply() error {
-	// Default to using the git deploy key to decrypt sealed secrets
-	if a.Params.sealedSecretKeyPath == "" && a.Params.gitDeployKeyPath != "" {
-		a.Params.sealedSecretKeyPath = a.Params.gitDeployKeyPath
-	}
-
 	var closer func()
 	var err error
 	cpath := filepath.Join(a.Params.gitPath, a.Params.clusterManifestPath)
@@ -117,6 +112,12 @@ func (a *Applier) initiateCluster(clusterManifestPath, machinesManifestPath stri
 		ns = a.Params.namespace
 	}
 
+	sealedSecretKeyPath := a.Params.sealedSecretKeyPath
+	if sealedSecretKeyPath == "" {
+		// Default to using the git deploy key to decrypt sealed secrets
+		sealedSecretKeyPath = a.Params.gitDeployKeyPath
+	}
+
 	// TODO(damien): Transform the controller image into an addon.
 	controllerImage, err := addons.UpdateImage(a.Params.controllerImage, sp.ClusterSpec.ImageRepository)
 	if err != nil {
@@ -140,7 +141,7 @@ func (a *Applier) initiateCluster(clusterManifestPath, machinesManifestPath stri
 			GitPath:          a.Params.gitPath,
 			GitDeployKeyPath: a.Params.gitDeployKeyPath,
 		},
-		SealedSecretKeyPath:  a.Params.sealedSecretKeyPath,
+		SealedSecretKeyPath:  sealedSecretKeyPath,
 		SealedSecretCertPath: a.Params.sealedSecretCertPath,
 		ConfigDirectory:      configDir,
 		ImageRepository:      sp.ClusterSpec.ImageRepository,

--- a/cmd/wksctl/apply/apply.go
+++ b/cmd/wksctl/apply/apply.go
@@ -75,7 +75,7 @@ func (a *Applier) Apply() error {
 		// Cluster and Machine manifests come from a Git repo that we'll clone for the duration of this command.
 		repo, err := manifests.CloneClusterAPIRepo(a.Params.gitURL, a.Params.gitBranch, a.Params.gitDeployKeyPath, a.Params.gitPath)
 		if err != nil {
-			return errors.Wrap(err, "manifests.Get")
+			return errors.Wrap(err, "CloneClusterAPIRepo")
 		}
 		defer repo.Close()
 

--- a/cmd/wksctl/kubeconfig/kubeconfig.go
+++ b/cmd/wksctl/kubeconfig/kubeconfig.go
@@ -64,12 +64,12 @@ func init() {
 }
 
 func kubeconfigRun(cmd *cobra.Command, args []string) error {
-	var cpath, mpath string
+	var clusterPath, machinesPath string
 
-	// TODO: deduplicate cpath/mpath evaluation between here and cmd/wksctl/apply
+	// TODO: deduplicate clusterPath/machinesPath evaluation between here and cmd/wksctl/apply
 	if kubeconfigOptions.gitURL == "" {
 		// Cluster and Machine manifests come from the local filesystem.
-		cpath, mpath = kubeconfigOptions.clusterManifestPath, kubeconfigOptions.machinesManifestPath
+		clusterPath, machinesPath = kubeconfigOptions.clusterManifestPath, kubeconfigOptions.machinesManifestPath
 	} else {
 		// Cluster and Machine manifests come from a Git repo that we'll clone for the duration of this command.
 		repo, err := manifests.CloneClusterAPIRepo(kubeconfigOptions.gitURL, kubeconfigOptions.gitBranch, kubeconfigOptions.gitDeployKeyPath, kubeconfigOptions.gitPath)
@@ -78,15 +78,15 @@ func kubeconfigRun(cmd *cobra.Command, args []string) error {
 		}
 		defer repo.Close()
 
-		if cpath, err = repo.ClusterManifestPath(); err != nil {
+		if clusterPath, err = repo.ClusterManifestPath(); err != nil {
 			return errors.Wrap(err, "ClusterManifestPath")
 		}
-		if mpath, err = repo.MachinesManifestPath(); err != nil {
+		if machinesPath, err = repo.MachinesManifestPath(); err != nil {
 			return errors.Wrap(err, "MachinesManifestPath")
 		}
 	}
 
-	return writeKubeconfig(cpath, mpath)
+	return writeKubeconfig(clusterPath, machinesPath)
 }
 
 func writeKubeconfig(cpath, mpath string) error {

--- a/cmd/wksctl/kubeconfig/kubeconfig.go
+++ b/cmd/wksctl/kubeconfig/kubeconfig.go
@@ -67,6 +67,7 @@ func kubeconfigRun(cmd *cobra.Command, args []string) error {
 	var clusterPath, machinesPath string
 
 	// TODO: deduplicate clusterPath/machinesPath evaluation between here and cmd/wksctl/apply
+	// https://github.com/weaveworks/wksctl/issues/58
 	if kubeconfigOptions.gitURL == "" {
 		// Cluster and Machine manifests come from the local filesystem.
 		clusterPath, machinesPath = kubeconfigOptions.clusterManifestPath, kubeconfigOptions.machinesManifestPath

--- a/cmd/wksctl/kubeconfig/kubeconfig.go
+++ b/cmd/wksctl/kubeconfig/kubeconfig.go
@@ -68,7 +68,7 @@ func kubeconfigRun(cmd *cobra.Command, args []string) error {
 
 	// TODO: deduplicate cpath/mpath evaluation between here and cmd/wksctl/apply
 	if kubeconfigOptions.gitURL == "" {
-		// Cluster and Manifests come from the local filesystem.
+		// Cluster and Machine manifests come from the local filesystem.
 		cpath, mpath = kubeconfigOptions.clusterManifestPath, kubeconfigOptions.machinesManifestPath
 	} else {
 		// Cluster and Machine manifests come from a Git repo that we'll clone for the duration of this command.

--- a/cmd/wksctl/kubeconfig/kubeconfig.go
+++ b/cmd/wksctl/kubeconfig/kubeconfig.go
@@ -64,21 +64,38 @@ func init() {
 }
 
 func kubeconfigRun(cmd *cobra.Command, args []string) error {
-	clusterManifestPath, machinesManifestPath, closer, err := manifests.Get(kubeconfigOptions.clusterManifestPath,
-		kubeconfigOptions.machinesManifestPath, kubeconfigOptions.gitURL, kubeconfigOptions.gitBranch, kubeconfigOptions.gitDeployKeyPath,
-		kubeconfigOptions.gitPath)
-	if closer != nil {
-		defer closer()
+	var cpath, mpath string
+
+	// TODO: deduplicate cpath/mpath evaluation between here and cmd/wksctl/apply
+	if kubeconfigOptions.gitURL == "" {
+		// Cluster and Manifests come from the local filesystem.
+		cpath, mpath = kubeconfigOptions.clusterManifestPath, kubeconfigOptions.machinesManifestPath
+	} else {
+		// Cluster and Machine manifests come from a Git repo that we'll clone for the duration of this command.
+		repo, err := manifests.CloneClusterAPIRepo(kubeconfigOptions.gitURL, kubeconfigOptions.gitBranch, kubeconfigOptions.gitDeployKeyPath, kubeconfigOptions.gitPath)
+		if err != nil {
+			return errors.Wrap(err, "CloneClusterAPIRepo")
+		}
+		defer repo.Close()
+
+		if cpath, err = repo.ClusterManifestPath(); err != nil {
+			return errors.Wrap(err, "ClusterManifestPath")
+		}
+		if mpath, err = repo.MachinesManifestPath(); err != nil {
+			return errors.Wrap(err, "MachinesManifestPath")
+		}
 	}
-	if err != nil {
-		return err
-	}
+
+	return writeKubeconfig(cpath, mpath)
+}
+
+func writeKubeconfig(cpath, mpath string) error {
 	wksHome, err := path.CreateDirectory(
 		path.WKSHome(kubeconfigOptions.artifactDirectory))
 	if err != nil {
 		return errors.Wrapf(err, "failed to create WKS home directory")
 	}
-	sp := specs.NewFromPaths(clusterManifestPath, machinesManifestPath)
+	sp := specs.NewFromPaths(cpath, mpath)
 
 	configStr, err := config.GetRemoteKubeconfig(sp, kubeconfigOptions.verbose, kubeconfigOptions.skipTLSVerify)
 	if err != nil {

--- a/cmd/wksctl/plan/view/view.go
+++ b/cmd/wksctl/plan/view/view.go
@@ -56,6 +56,7 @@ func planRun(cmd *cobra.Command, args []string) error {
 	var clusterPath, machinesPath string
 
 	// TODO: deduplicate clusterPath/machinesPath evaluation between here and cmd/wksctl/apply
+	// https://github.com/weaveworks/wksctl/issues/58
 	if viewOptions.gitURL == "" {
 		// Cluster and Machine manifests come from the local filesystem.
 		clusterPath, machinesPath = viewOptions.clusterManifestPath, viewOptions.machinesManifestPath

--- a/cmd/wksctl/plan/view/view.go
+++ b/cmd/wksctl/plan/view/view.go
@@ -57,7 +57,7 @@ func planRun(cmd *cobra.Command, args []string) error {
 
 	// TODO: deduplicate cpath/mpath evaluation between here and cmd/wksctl/apply
 	if viewOptions.gitURL == "" {
-		// Cluster and Manifests come from the local filesystem.
+		// Cluster and Machine manifests come from the local filesystem.
 		cpath, mpath = viewOptions.clusterManifestPath, viewOptions.machinesManifestPath
 	} else {
 		// Cluster and Machine manifests come from a Git repo that we'll clone for the duration of this command.

--- a/cmd/wksctl/plan/view/view.go
+++ b/cmd/wksctl/plan/view/view.go
@@ -31,7 +31,6 @@ var viewOptions struct {
 	gitBranch            string
 	gitPath              string
 	gitDeployKeyPath     string
-	sealedSecretKeyPath  string
 	sealedSecretCertPath string
 	configDirectory      string
 	verbose              bool
@@ -46,26 +45,14 @@ func init() {
 	Cmd.Flags().StringVar(&viewOptions.gitBranch, "git-branch", "master", "Git branch WKS should use to read your cluster")
 	Cmd.Flags().StringVar(&viewOptions.gitPath, "git-path", ".", "Relative path to files in Git")
 	Cmd.Flags().StringVar(&viewOptions.gitDeployKeyPath, "git-deploy-key", "", "Path to the Git deploy key")
-	Cmd.Flags().StringVar(&viewOptions.sealedSecretKeyPath, "sealed-secret-key", "", "Path to a key used to decrypt sealed secrets")
 	Cmd.Flags().StringVar(&viewOptions.sealedSecretCertPath, "sealed-secret-cert", "", "Path to a certificate used to encrypt sealed secrets")
 	Cmd.Flags().StringVar(&viewOptions.configDirectory, "config-directory", ".", "Directory containing configuration information for the cluster")
 
 	// Intentionally shadows the globally defined --verbose flag.
 	Cmd.Flags().BoolVar(&viewOptions.verbose, "verbose", false, "Enable verbose output")
-
-	// Default to using the git deploy key to decrypt sealed secrets
-	// BUG: CLI flags are not evaluated yet at this point!
-	if viewOptions.sealedSecretKeyPath == "" && viewOptions.gitDeployKeyPath != "" {
-		viewOptions.sealedSecretKeyPath = viewOptions.gitDeployKeyPath
-	}
 }
 
 func planRun(cmd *cobra.Command, args []string) error {
-	// Default to using the git deploy key to decrypt sealed secrets
-	if viewOptions.sealedSecretKeyPath == "" && viewOptions.gitDeployKeyPath != "" {
-		viewOptions.sealedSecretKeyPath = viewOptions.gitDeployKeyPath
-	}
-
 	var closer func()
 	var err error
 	cpath := filepath.Join(viewOptions.gitPath, viewOptions.clusterManifestPath)

--- a/cmd/wksctl/plan/view/view.go
+++ b/cmd/wksctl/plan/view/view.go
@@ -53,12 +53,12 @@ func init() {
 }
 
 func planRun(cmd *cobra.Command, args []string) error {
-	var cpath, mpath string
+	var clusterPath, machinesPath string
 
-	// TODO: deduplicate cpath/mpath evaluation between here and cmd/wksctl/apply
+	// TODO: deduplicate clusterPath/machinesPath evaluation between here and cmd/wksctl/apply
 	if viewOptions.gitURL == "" {
 		// Cluster and Machine manifests come from the local filesystem.
-		cpath, mpath = viewOptions.clusterManifestPath, viewOptions.machinesManifestPath
+		clusterPath, machinesPath = viewOptions.clusterManifestPath, viewOptions.machinesManifestPath
 	} else {
 		// Cluster and Machine manifests come from a Git repo that we'll clone for the duration of this command.
 		repo, err := manifests.CloneClusterAPIRepo(viewOptions.gitURL, viewOptions.gitBranch, viewOptions.gitDeployKeyPath, viewOptions.gitPath)
@@ -67,15 +67,15 @@ func planRun(cmd *cobra.Command, args []string) error {
 		}
 		defer repo.Close()
 
-		if cpath, err = repo.ClusterManifestPath(); err != nil {
+		if clusterPath, err = repo.ClusterManifestPath(); err != nil {
 			return errors.Wrap(err, "ClusterManifestPath")
 		}
-		if mpath, err = repo.MachinesManifestPath(); err != nil {
+		if machinesPath, err = repo.MachinesManifestPath(); err != nil {
 			return errors.Wrap(err, "MachinesManifestPath")
 		}
 	}
 
-	return displayPlan(cpath, mpath)
+	return displayPlan(clusterPath, machinesPath)
 }
 
 func displayPlan(clusterManifestPath, machinesManifestPath string) error {


### PR DESCRIPTION
Part of #33. Please review commit by commit.

2d78d2e (#8) changed the default `git-path` from `""` to `"."` which (eventually) led to absolute paths being prepended with `"."` which effectively made them relative to CWD. This broke the integration tests (that went unnoticed because they're currently disabled)

This PR:
- fixes the issue above - makes tests pass
- refactors `syncRepo` and `manifests.Get` to achieve more separation
- improves `defer` calls in several places
- improves flag handling by preventing flag value rewrite during runtime
- refactors all 3 callsites of `manifests.Get` which eventually made them identical. It makes sense to extract shared code into one place, but I'm not doing it in this PR to avoid scope creep.