### PR TITLE
version: set default ImageTag to 0.8.0-beta.1, improve the comment

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,9 +1,10 @@
 package version
 
 var (
-	// The constants below are to be set by flags passed to `go build`.
-	// Examples: -X version.Version=xxxxx -X version.ImageTag=yyyyy
+	// The constants below are to be overridden by linker flags passed to `go build`.
+	// Examples: -X github.com/weaveworks/wksctl/pkg/version.Version=xxxxx -X github.com/weaveworks/wksctl/pkg/version.ImageTag=yyyyy
+	// If wksctl is used as an imported module, the importing program shall override these values using the linker flags above. If not done, the defaults below will be used instead.
 
 	Version  = "undefined"
-	ImageTag = "latest"
+	ImageTag = "0.8.0-beta.1"
 )


### PR DESCRIPTION
Part of #33.

This PR sets the default `ImageTag` of images used by `wksctl` (in practice, today that's `quay.io/wksctl/controller` only) to `0.8.0-beta.1` (the most recent version that's available - to be updated to the next stable release).

The default `ImageTag` is used by programs that import wksctl as a Go module.