### PR TITLE
fixes -v flag, reflects reality that `verbose` is not a global flag

### DIFF
--- a/cmd/wksctl/apply/apply.go
+++ b/cmd/wksctl/apply/apply.go
@@ -53,7 +53,7 @@ func init() {
 	Cmd.Flags().BoolVar(&globalParams.useManifestNamespace, "use-manifest-namespace", false, "use namespaces from supplied manifests (overriding any --namespace argument)")
 
 	// Intentionally shadows the globally defined --verbose flag.
-	Cmd.Flags().BoolVar(&globalParams.verbose, "verbose", false, "Enable verbose output")
+	Cmd.Flags().BoolVarP(&globalParams.verbose, "verbose", "v", false, "Enable verbose output")
 
 	// Hide controller-image flag as it is a helper/debug flag.
 	Cmd.Flags().StringVar(&globalParams.controllerImage, "controller-image", "", "Controller image override")

--- a/cmd/wksctl/apply/apply.go
+++ b/cmd/wksctl/apply/apply.go
@@ -52,6 +52,7 @@ func init() {
 	Cmd.Flags().StringVar(&globalParams.namespace, "namespace", manifest.DefaultNamespace, "namespace override for WKS components")
 	Cmd.Flags().BoolVar(&globalParams.useManifestNamespace, "use-manifest-namespace", false, "use namespaces from supplied manifests (overriding any --namespace argument)")
 
+	// Intentionally shadows the globally defined --verbose flag.
 	Cmd.Flags().BoolVarP(&globalParams.verbose, "verbose", "v", false, "Enable verbose output")
 
 	// Hide controller-image flag as it is a helper/debug flag.

--- a/cmd/wksctl/apply/apply.go
+++ b/cmd/wksctl/apply/apply.go
@@ -52,7 +52,6 @@ func init() {
 	Cmd.Flags().StringVar(&globalParams.namespace, "namespace", manifest.DefaultNamespace, "namespace override for WKS components")
 	Cmd.Flags().BoolVar(&globalParams.useManifestNamespace, "use-manifest-namespace", false, "use namespaces from supplied manifests (overriding any --namespace argument)")
 
-	// Intentionally shadows the globally defined --verbose flag.
 	Cmd.Flags().BoolVarP(&globalParams.verbose, "verbose", "v", false, "Enable verbose output")
 
 	// Hide controller-image flag as it is a helper/debug flag.

--- a/cmd/wksctl/kubeconfig/kubeconfig.go
+++ b/cmd/wksctl/kubeconfig/kubeconfig.go
@@ -59,6 +59,7 @@ func init() {
 		"Enables kubectl to communicate with the API w/o verifying the certificate")
 	Cmd.Flags().MarkHidden("insecure-skip-tls-verify")
 
+	// Intentionally shadows the globally defined --verbose flag.
 	Cmd.Flags().BoolVarP(&kubeconfigOptions.verbose, "verbose", "v", false, "Enable verbose output")
 }
 

--- a/cmd/wksctl/kubeconfig/kubeconfig.go
+++ b/cmd/wksctl/kubeconfig/kubeconfig.go
@@ -60,7 +60,7 @@ func init() {
 	Cmd.Flags().MarkHidden("insecure-skip-tls-verify")
 
 	// Intentionally shadows the globally defined --verbose flag.
-	Cmd.Flags().BoolVar(&kubeconfigOptions.verbose, "verbose", false, "Enable verbose output")
+	Cmd.Flags().BoolVarP(&kubeconfigOptions.verbose, "verbose", "v", false, "Enable verbose output")
 }
 
 func kubeconfigRun(cmd *cobra.Command, args []string) error {

--- a/cmd/wksctl/kubeconfig/kubeconfig.go
+++ b/cmd/wksctl/kubeconfig/kubeconfig.go
@@ -59,7 +59,6 @@ func init() {
 		"Enables kubectl to communicate with the API w/o verifying the certificate")
 	Cmd.Flags().MarkHidden("insecure-skip-tls-verify")
 
-	// Intentionally shadows the globally defined --verbose flag.
 	Cmd.Flags().BoolVarP(&kubeconfigOptions.verbose, "verbose", "v", false, "Enable verbose output")
 }
 

--- a/cmd/wksctl/main.go
+++ b/cmd/wksctl/main.go
@@ -41,6 +41,8 @@ func configureLogger(cmd *cobra.Command, args []string) {
 }
 
 func main() {
+	rootCmd.PersistentFlags().BoolVarP(&options.verbose, "verbose", "v", false, "Enable verbose output")
+
 	rootCmd.AddCommand(addon.Cmd)
 	rootCmd.AddCommand(apply.Cmd)
 	rootCmd.AddCommand(applyaddons.Cmd)

--- a/cmd/wksctl/main.go
+++ b/cmd/wksctl/main.go
@@ -41,8 +41,6 @@ func configureLogger(cmd *cobra.Command, args []string) {
 }
 
 func main() {
-	rootCmd.PersistentFlags().BoolVarP(&options.verbose, "verbose", "v", false, "Enable verbose output")
-
 	rootCmd.AddCommand(addon.Cmd)
 	rootCmd.AddCommand(apply.Cmd)
 	rootCmd.AddCommand(applyaddons.Cmd)

--- a/cmd/wksctl/plan/view/view.go
+++ b/cmd/wksctl/plan/view/view.go
@@ -48,7 +48,6 @@ func init() {
 	Cmd.Flags().StringVar(&viewOptions.sealedSecretCertPath, "sealed-secret-cert", "", "Path to a certificate used to encrypt sealed secrets")
 	Cmd.Flags().StringVar(&viewOptions.configDirectory, "config-directory", ".", "Directory containing configuration information for the cluster")
 
-	// Intentionally shadows the globally defined --verbose flag.
 	Cmd.Flags().BoolVarP(&viewOptions.verbose, "verbose", "v", false, "Enable verbose output")
 }
 

--- a/cmd/wksctl/plan/view/view.go
+++ b/cmd/wksctl/plan/view/view.go
@@ -48,6 +48,7 @@ func init() {
 	Cmd.Flags().StringVar(&viewOptions.sealedSecretCertPath, "sealed-secret-cert", "", "Path to a certificate used to encrypt sealed secrets")
 	Cmd.Flags().StringVar(&viewOptions.configDirectory, "config-directory", ".", "Directory containing configuration information for the cluster")
 
+	// Intentionally shadows the globally defined --verbose flag.
 	Cmd.Flags().BoolVarP(&viewOptions.verbose, "verbose", "v", false, "Enable verbose output")
 }
 

--- a/cmd/wksctl/plan/view/view.go
+++ b/cmd/wksctl/plan/view/view.go
@@ -49,7 +49,7 @@ func init() {
 	Cmd.Flags().StringVar(&viewOptions.configDirectory, "config-directory", ".", "Directory containing configuration information for the cluster")
 
 	// Intentionally shadows the globally defined --verbose flag.
-	Cmd.Flags().BoolVar(&viewOptions.verbose, "verbose", false, "Enable verbose output")
+	Cmd.Flags().BoolVarP(&viewOptions.verbose, "verbose", "v", false, "Enable verbose output")
 }
 
 func planRun(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
fixes: #64 

Furthermore, the `verbose` flag was listed as a persistent flag, but in fact it only exists for the `apply`, `kubeconfig`, and `view` commands.  At the heart of this issue is a mismatch between the main `wksctl` command telling the user that the `--verbose` flag is global when it is in fact not.  The solution to this problem is, therefore, to remove the flag from global listing, and leave it for those commands that actually do implement it (something cobra does automatically for us, and by default).