### PR TITLE
release: Update the location of the Version and ImageTag variables

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -6,8 +6,8 @@ builds:
   main: ./cmd/wksctl
   binary: wksctl
   ldflags:
-    - -X main.version={{.Version}}
-    - -X main.imageTag={{.Env.IMAGE_TAG}}
+    - -X github.com/weaveworks/wksctl/pkg/version.Version={{.Version}}
+    - -X github.com/weaveworks/wksctl/pkg/version.ImageTag={{.Env.IMAGE_TAG}}
   env:
     - CGO_ENABLED=0
     - GO111MODULE=on


### PR DESCRIPTION
Those variables have moved package, update the goreleaser configuration
accordingly.

Fixes: #68