### PR TITLE
Add snap package definition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ tf.json
 
 # Docs
 docs/_build
+
+# Snap images
+*.snap

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,49 @@
+name: wksctl
+version: git
+summary: Open Source Weaveworks Kubernetes Subscription
+description: >
+  wksctl allows simple creation of a Kubernetes cluster given a set of IP addresses and an SSH key. It
+  can be run in a standalone environment but is best used via a GitOps approach in which cluster and
+  machine descriptions are stored in Git and the state of the cluster tracks changes to the descriptions.
+   
+  Its features include:
+  
+  * simple creation of Kubernetes clusters
+  * manage cluster and machine descriptions using Git
+  * manage addons like Weave Net or Flux
+  * Sealed Secret integration
+confinement: devmode
+base: core18
+
+parts:
+  wksctl:
+    source: .
+    # Don't use go plugin because it doesn't seem to work with Go modules
+    plugin: nil
+    override-build: |
+      export GOBIN=$SNAPCRAFT_PART_INSTALL/bin
+      go build -o $GOBIN/wksctl ./cmd/wksctl
+    build-environment:
+      - GO111MODULE: 'on'
+      - CGO_ENABLED: '0'
+    build-packages:
+      - gcc
+      - git
+    build-snaps:
+      - go/1.12/stable
+
+plugs:
+  kube-config:
+    interface: personal-files
+    read:
+    - $HOME/.kube
+    - $HOME/.minikube
+    - $HOME/.config/k3d  # hard-coded $XDG_CONFIG_HOME for the common case
+
+apps:
+  wksctl:
+    command: bin/wksctl
+    plugs:
+    - kube-config
+    - network
+    - network-bind

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -6,14 +6,11 @@ description: >
   can be run in a standalone environment but is best used via a GitOps approach in which cluster and
   machine descriptions are stored in Git and the state of the cluster tracks changes to the descriptions.
    
-  Its features include:
-  
-  * simple creation of Kubernetes clusters
-  * manage cluster and machine descriptions using Git
-  * manage addons like Weave Net or Flux
-  * Sealed Secret integration
-confinement: devmode
-grade: devel
+  Its features include: simple creation of Kubernetes clusters, manage cluster and machine descriptions using Git,
+  manage addons like Weave Net or Flux, Sealed Secret integration
+# Needs to be able to read files passed as args, e.g. wksctl apply --machines, --cluster
+confinement: classic
+grade: stable
 base: core18
 
 parts:
@@ -23,7 +20,7 @@ parts:
     plugin: nil
     override-build: |
       export GOBIN=$SNAPCRAFT_PART_INSTALL/bin
-      export VERSION=$(git tag -l | egrep -v '^(chart-|helm-|master-|pre-split)' | sort --version-sort | tail -n1)
+      export VERSION=$(git tag -l | egrep -v '^(chart-|helm-|master-|pre-split|[a-z])' | sort --version-sort | tail -n1)
       go build -ldflags "-X github.com/weaveworks/wksctl/pkg/version.Version=$VERSION" -o $GOBIN/wksctl ./cmd/wksctl
     build-environment:
       - GO111MODULE: 'on'
@@ -31,18 +28,6 @@ parts:
     build-snaps:
       - go/1.12/stable
 
-plugs:
-  kube-config:
-    interface: personal-files
-    read:
-    - $HOME/.kube
-    - $HOME/.minikube
-    - $HOME/.wks
-
 apps:
   wksctl:
     command: bin/wksctl
-    plugs:
-    - kube-config
-    - network
-    - network-bind

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -28,9 +28,6 @@ parts:
     build-environment:
       - GO111MODULE: 'on'
       - CGO_ENABLED: '0'
-    build-packages:
-      - gcc
-      - git
     build-snaps:
       - go/1.12/stable
 
@@ -40,7 +37,7 @@ plugs:
     read:
     - $HOME/.kube
     - $HOME/.minikube
-    - $HOME/.config/k3d  # hard-coded $XDG_CONFIG_HOME for the common case
+    - $HOME/.wks
 
 apps:
   wksctl:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: wksctl
 version: git
-summary: Open Source Weaveworks Kubernetes Subscription
+summary: Open Source Weaveworks Kubernetes System
 description: >
   wksctl allows simple creation of a Kubernetes cluster given a set of IP addresses and an SSH key. It
   can be run in a standalone environment but is best used via a GitOps approach in which cluster and

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -13,6 +13,7 @@ description: >
   * manage addons like Weave Net or Flux
   * Sealed Secret integration
 confinement: devmode
+grade: devel
 base: core18
 
 parts:
@@ -22,7 +23,8 @@ parts:
     plugin: nil
     override-build: |
       export GOBIN=$SNAPCRAFT_PART_INSTALL/bin
-      go build -o $GOBIN/wksctl ./cmd/wksctl
+      export VERSION=$(git tag -l | egrep -v '^(chart-|helm-|master-|pre-split)' | sort --version-sort | tail -n1)
+      go build -ldflags "-X github.com/weaveworks/wksctl/pkg/version.Version=$VERSION" -o $GOBIN/wksctl ./cmd/wksctl
     build-environment:
       - GO111MODULE: 'on'
       - CGO_ENABLED: '0'

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -31,9 +31,7 @@ parts:
 plugs:	
   kube-config:	
     interface: personal-files	
-    read:	
-    - $HOME/.kube	
-    - $HOME/.minikube	
+    write:	
     - $HOME/.wks
 
 apps:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -39,6 +39,7 @@ apps:
     command: bin/wksctl
     plugs:
     - kube-config
+    - removable-media
     - home
     - network	
     - network-bind

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -5,11 +5,11 @@ description: >
   wksctl allows simple creation of a Kubernetes cluster given a set of IP addresses and an SSH key. It
   can be run in a standalone environment but is best used via a GitOps approach in which cluster and
   machine descriptions are stored in Git and the state of the cluster tracks changes to the descriptions.
-   
-  Its features include: simple creation of Kubernetes clusters, manage cluster and machine descriptions using Git,
+
+  Its features include simple creation of Kubernetes clusters, manage cluster and machine descriptions using Git,
   manage addons like Weave Net or Flux, Sealed Secret integration
-# Needs to be able to read files passed as args, e.g. wksctl apply --machines, --cluster
-confinement: classic
+
+confinement: strict
 grade: stable
 base: core18
 
@@ -28,6 +28,19 @@ parts:
     build-snaps:
       - go/1.12/stable
 
+plugs:	
+  kube-config:	
+    interface: personal-files	
+    read:	
+    - $HOME/.kube	
+    - $HOME/.minikube	
+    - $HOME/.wks
+
 apps:
   wksctl:
     command: bin/wksctl
+    plugs:
+    - kube-config
+    - home
+    - network	
+    - network-bind


### PR DESCRIPTION
This PR should enable users to install `wksctl` via `snap` command on Ubuntu systems.

Used a mix of https://snapcraft.io/docs/go-applications and [fluxcd/flux template](https://github.com/fluxcd/flux/blob/cbf2029ef65a96f9fbff66ef605d53e92800ef27/snap/snapcraft.yaml) for the `snapcraft.yaml` draft (thanks @dholbach for leaving enough traces around :)).

#### Checklist

* [x] Add `snapcraft.yaml` that compiles into a working binary
* [x] Verify and tighten all the interface permissions
  - ~Switched to [classic confinement](https://snapcraft.io/docs/snap-confinement) as `wksctl` needs to read files passed to it via command line args, like `--cluster` and `--machines` args in `wksctl apply`, and we don't know where those file might be stored locally~
  - Will be using [strict confinement](https://snapcraft.io/docs/snap-confinement) - see the [store request discussion](https://forum.snapcraft.io/t/classic-confinement-for-wksctl/13383) for the full context
* [x] Test out basic `wksctl` commands in the snap install
* [ ] Publish the snap package
  - [ ] Resolve the [store request](https://forum.snapcraft.io/t/classic-confinement-for-wksctl/13383) manual review
  - [ ] Release to edge
  - [ ] Release to stable
* [ ] Update the package metadata - https://snapcraft.io/wksctl/listing
  - [ ] Update publisher account details (full name, username, email address) to point to Weaveworks instead of a personal account
  - [ ] Add a snap icon - #77 
  - [ ] Add video, images, featured banner
  - [ ] Add contact email
* [ ] Update the docs with `snap` install instructions
  - Will do once we have the stable release pushed

#### TODO in follow-up PRs

* Integrate with Github for automatic snap version updates - https://snapcraft.io/build
  - Sync with @dholbach on this one as `fluxctl` and `eksctl` might need the same
