### PR TITLE
manifests: bugfix: return the fq path from MachinesManifestPath() + tests

### DIFF
--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -37,7 +37,7 @@ func (r *ClusterAPIRepo) MachinesManifestPath() (string, error) {
 	for _, c := range candidates {
 		fqCand := filepath.Join(r.worktreePath, r.subdir, c)
 		if _, err := os.Stat(fqCand); err == nil {
-			return c, nil
+			return fqCand, nil
 		}
 	}
 	return "", errors.New("machines manifest not found")


### PR DESCRIPTION
Fixes a bug where the `MachinesManifestPath` returns a path relative to the repo root where clients expect it to return an absolute path.