### PR TITLE
implement profile feature

### DIFF
--- a/cmd/wksctl/main.go
+++ b/cmd/wksctl/main.go
@@ -14,6 +14,7 @@ import (
 	initpkg "github.com/weaveworks/wksctl/cmd/wksctl/init"
 	"github.com/weaveworks/wksctl/cmd/wksctl/kubeconfig"
 	"github.com/weaveworks/wksctl/cmd/wksctl/plan"
+	"github.com/weaveworks/wksctl/cmd/wksctl/profile"
 	"github.com/weaveworks/wksctl/cmd/wksctl/registrysynccommands"
 	"github.com/weaveworks/wksctl/cmd/wksctl/version"
 	"github.com/weaveworks/wksctl/cmd/wksctl/zshcompletions"
@@ -49,6 +50,7 @@ func main() {
 	rootCmd.AddCommand(initpkg.Cmd)
 	rootCmd.AddCommand(kubeconfig.Cmd)
 	rootCmd.AddCommand(plan.Cmd)
+	rootCmd.AddCommand(profile.Cmd)
 	rootCmd.AddCommand(registrysynccommands.Cmd)
 	rootCmd.AddCommand(version.Cmd)
 

--- a/cmd/wksctl/profile/constants/constants.go
+++ b/cmd/wksctl/profile/constants/constants.go
@@ -1,0 +1,6 @@
+package constants
+
+const (
+	AppDevAlias   = "app-dev"
+	AppDevRepoURL = "git@github.com:weaveworks/eks-quickstart-app-dev"
+)

--- a/cmd/wksctl/profile/disable/disable.go
+++ b/cmd/wksctl/profile/disable/disable.go
@@ -1,0 +1,96 @@
+package disable
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/weaveworks/wksctl/cmd/wksctl/profile/constants"
+	"github.com/weaveworks/wksctl/pkg/git"
+)
+
+var Cmd = &cobra.Command{
+	Use:   "disable",
+	Short: "disable profile",
+	Long: `To disable the profile, run
+
+wksctl profile disable --git-url=<profile_repository> [--revision=master] [--push=true]
+
+Please make sure that there is no staged change on the current branch before disable a profile.
+`,
+	Args: profileDisableArgs,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		return profileDisable(profileDisableParams)
+	},
+	SilenceUsage: true,
+}
+
+type profileDisableFlags struct {
+	gitUrl     string
+	push       bool
+	profileDir string
+}
+
+var profileDisableParams profileDisableFlags
+
+func init() {
+	Cmd.Flags().StringVar(&profileDisableParams.profileDir, "profile-dir", "profiles", "specify a directory for storing profiles")
+	Cmd.Flags().StringVar(&profileDisableParams.gitUrl, "git-url", "", "enable profile from the Git URL")
+	Cmd.Flags().BoolVar(&profileDisableParams.push, "push", true, "auto push after disable the profile")
+}
+
+func profileDisableArgs(cmd *cobra.Command, args []string) error {
+	if len(args) != 0 {
+		return errors.New("profile disable does not require any argument")
+	}
+	return nil
+}
+
+func profileDisable(params profileDisableFlags) error {
+	repoUrl := params.gitUrl
+	if repoUrl == constants.AppDevAlias {
+		repoUrl = constants.AppDevRepoURL
+	}
+
+	if err := git.IsGitURL(repoUrl); err != nil {
+		return err
+	}
+
+	hostName, repoName, err := git.HostAndRepoPath(repoUrl)
+	if err != nil {
+		return err
+	}
+
+	profilePath := path.Join(params.profileDir, hostName, repoName)
+	// profilePath should exist
+	if _, err := os.Stat(profilePath); err != nil {
+		return err
+	}
+
+	// check if there is staged changes
+	if err := git.HasNoStagedChanges(); err != nil {
+		return err
+	}
+
+	log.Info("Removing profile from the local repository...")
+	if err := git.RmRecursive(profilePath); err != nil {
+		return err
+	}
+	log.Info("Removed profile from the local repository.")
+
+	if err := git.Commit(fmt.Sprintf("Disable profile: %q", profilePath)); err != nil {
+		return err
+	}
+
+	// Similar to enable, the default behaviour is auto-commit and push
+	if params.push {
+		if err := git.Push(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/cmd/wksctl/profile/enable/enable.go
+++ b/cmd/wksctl/profile/enable/enable.go
@@ -1,0 +1,85 @@
+package enable
+
+import (
+	"errors"
+	"path"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/weaveworks/wksctl/cmd/wksctl/profile/constants"
+	"github.com/weaveworks/wksctl/pkg/git"
+)
+
+var Cmd = &cobra.Command{
+	Use:   "enable",
+	Short: "Enable profile",
+	Long: `To enable the profile from a specific git URL, run
+
+wksctl profile enable --git-url=<profile_repository> [--revision=master] [--profile-dir=profiles] [--push=true]
+
+If you'd like to specify the revision other than the master branch, use --revision flag.
+To disable auto-push, pass --push=false.
+`,
+	Args: profileEnableArgs,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		return profileEnableRun(profileEnableParams)
+	},
+	SilenceUsage: true,
+}
+
+type profileEnableFlags struct {
+	gitUrl     string
+	revision   string
+	push       bool
+	profileDir string
+}
+
+var profileEnableParams profileEnableFlags
+
+func init() {
+	Cmd.Flags().StringVar(&profileEnableParams.profileDir, "profile-dir", "profiles", "specify a directory for storing profiles")
+	Cmd.Flags().StringVar(&profileEnableParams.gitUrl, "git-url", "", "enable profile from the gitUrl")
+	Cmd.Flags().StringVar(&profileEnableParams.revision, "revision", "master", "use this revision of the profile")
+	Cmd.Flags().BoolVar(&profileEnableParams.push, "push", true, "auto push after enable the profile")
+}
+
+func profileEnableArgs(cmd *cobra.Command, args []string) error {
+	if len(args) != 0 {
+		return errors.New("profile enable does not require any argument")
+	}
+	return nil
+}
+
+func profileEnableRun(params profileEnableFlags) error {
+	repoUrl := params.gitUrl
+
+	if repoUrl == constants.AppDevAlias {
+		repoUrl = constants.AppDevRepoURL
+	}
+
+	if err := git.IsGitURL(repoUrl); err != nil {
+		return err
+	}
+
+	hostName, repoName, err := git.HostAndRepoPath(repoUrl)
+	if err != nil {
+		return err
+	}
+	clonePath := path.Join(params.profileDir, hostName, repoName)
+
+	log.Info("Adding the profile to the local repository...")
+	err = git.SubtreeAdd(clonePath, repoUrl, params.revision)
+	if err != nil {
+		return err
+	}
+	log.Info("Added the profile to the local repository.")
+
+	// The default behaviour is auto-commit and push
+	if params.push {
+		if err := git.Push(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/cmd/wksctl/profile/profile.go
+++ b/cmd/wksctl/profile/profile.go
@@ -1,0 +1,18 @@
+package profile
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/weaveworks/wksctl/cmd/wksctl/profile/disable"
+	"github.com/weaveworks/wksctl/cmd/wksctl/profile/enable"
+)
+
+var Cmd = &cobra.Command{
+	Use:     "profile",
+	Aliases: []string{"profile"},
+	Short:   "Profile management",
+}
+
+func init() {
+	Cmd.AddCommand(enable.Cmd)
+	Cmd.AddCommand(disable.Cmd)
+}

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/weaveworks/footloose v0.0.0-20190829132911-efbcbb7a6390
 	github.com/weaveworks/go-checkpoint v0.0.0-20170503165305-ebbb8b0518ab
 	github.com/weaveworks/launcher v0.0.0-20180824102238-59a4fcc32c9c
+	github.com/whilp/git-urls v0.0.0-20160530060445-31bac0d230fa
 	go.uber.org/atomic v1.4.0 // indirect
 	go.uber.org/multierr v1.1.0 // indirect
 	go.uber.org/zap v1.10.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -268,6 +268,8 @@ github.com/weaveworks/go-checkpoint v0.0.0-20170503165305-ebbb8b0518ab h1:mW+hgc
 github.com/weaveworks/go-checkpoint v0.0.0-20170503165305-ebbb8b0518ab/go.mod h1:qkbvw5GPibQ/Nf7IZJL0UoLwmJ6858b4S/hUWRd+cH4=
 github.com/weaveworks/launcher v0.0.0-20180824102238-59a4fcc32c9c h1:YTNC1c2AM3xjrL6DM4vuq0HNJ79GFR8ScT+QKWadFUw=
 github.com/weaveworks/launcher v0.0.0-20180824102238-59a4fcc32c9c/go.mod h1:w9Z1vnQmPobkEZ0F3oyiqRYP+62qDqTGnK6t5uhe1kg=
+github.com/whilp/git-urls v0.0.0-20160530060445-31bac0d230fa h1:rW+Lu6281ed/4XGuVIa4/YebTRNvoUJlfJ44ktEVwZk=
+github.com/whilp/git-urls v0.0.0-20160530060445-31bac0d230fa/go.mod h1:2rx5KE5FLD0HRfkkpyn8JwbVLBdhgeiOb2D2D9LLKM4=
 github.com/xanzy/ssh-agent v0.2.0 h1:Adglfbi5p9Z0BmK2oKU9nTG+zKfniSfnaMYB+ULd+Ro=
 github.com/xanzy/ssh-agent v0.2.0/go.mod h1:0NyE30eGUDliuLEHJgYte/zncp2zdTStcOnWhgSqHD8=
 github.com/xiang90/probing v0.0.0-20160813154853-07dd2e8dfe18/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -1,0 +1,76 @@
+package git
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	giturls "github.com/whilp/git-urls"
+)
+
+func gitExec(args ...string) error {
+	cmd := exec.Command("git", args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+func HasNoStagedChanges() error {
+	return errors.Wrap(gitExec("diff", "--staged", "--exit-code"), "repository contains staged changes")
+}
+
+func RmRecursive(path string) error {
+	return gitExec("rm", "-r", "--", path)
+}
+
+func AddAll(path string) error {
+	return gitExec("add", "-A", path)
+}
+
+func SubtreeAdd(path, repository, revision string) error {
+	return gitExec("subtree", "add", "--squash", "--prefix", path, repository, revision)
+}
+
+func Commit(message string) error {
+	log.Infof("Committing the changes...")
+	err := gitExec("commit", "-m", message)
+	if err == nil {
+		log.Info("Committed the changes.")
+	}
+	return err
+}
+
+func Push() error {
+	log.Info("Pushing to the remote...")
+	err := gitExec("push", "-v", "origin", "HEAD")
+	if err == nil {
+		log.Info("Pushed successfully.")
+	}
+	return err
+}
+
+func HostAndRepoPath(repoURL string) (string, string, error) {
+	url, err := giturls.Parse(repoURL)
+	if err != nil {
+		return "", "", errors.Wrapf(err, "unable to parse git URL '%s'", repoURL)
+	}
+
+	return url.Hostname(), strings.TrimRight(url.Path, ".git"), nil
+}
+
+func IsGitURL(rawURL string) error {
+	parsedURL, err := giturls.Parse(rawURL)
+	if err != nil {
+		return err
+	}
+	if !parsedURL.IsAbs() {
+		return fmt.Errorf("URL %q does not have a scheme", parsedURL)
+	}
+	if parsedURL.Hostname() == "" {
+		return fmt.Errorf("URL %q has an empty hostname", parsedURL)
+	}
+	return nil
+}


### PR DESCRIPTION
This PR implements the feature described in #82.
The plan is to implement `profile` commands with 2 sub-commands `enable` and `disable`.

**Check List**

- [x] `wksctl profile enable`
  This command accepts 2 flags `--repository` and `--revision` (a branch, a tag, a commit id).
  `--repository` must be specified. `--revision` default value is `master`.

  - [x] **Case 1**: Enable from a repo 
  ```
   $ ~/.wks/bin/wksctl profile enable \
        --repository=https://github.com/chanwit/podinfo-profile
  ```
  The command in **Case 1** will add codes from the **master** branch of `https://github.com/chanwit/podinfo-profile` into the local repository, then `add`, `commit` and `push`.

  - [x] **Case 2**: Enable with a specific commit
  ```
   $ ~/.wks/bin/wksctl profile enable \
        --repository=https://github.com/chanwit/podinfo-profile \
        --revision=5adc1e3976d635b224ea106fbad8cb6cedf8a3cc
  ```
  The command in **Case 2** gives a commit to `--revision` flag, so that users could specifically enable the profile with the specific commit.

  - [x] **Case 3**: Enable with a specific tag
  ```
   $ ~/.wks/bin/wksctl profile enable \
        --repository=https://github.com/chanwit/podinfo-profile \
        --revision=v0.1.0
  ```
  The command in **Case 3** gives a tag to `--revision` flag, so that users could specifically enable the profile with the specific tag.

  - [x] **Case 4**: Enable with no-comnit (and no push)
  ```
   $ ~/.wks/bin/wksctl profile enable \
        --no-commit \
        --repository=https://github.com/chanwit/podinfo-profile
  ```
  The command in **Case 4** profile the `--no-commit` flag. This flag prevents `profile enable` to commit changes and allow the users to manually tweak profile codes, commit and push at their convenience.

- [x] **Upgrade:** When the user tries to enable the same profile again onto the local repo, it will return the error saying that the profile is already enabled. To upgrade, the user needs to manually disable the old version of the profile first, then enable a new version of the profile. **Why:** This is to prevent users to accidentally override their codes in case of users already made changes to the profile.

- [x] `wksctl profile disable`
  - [x] **Case 1**: Disable the existing profile
  ```
   $ ~/.wks/bin/wksctl profile disable \
        --repository=https://github.com/chanwit/podinfo-profile
  ```
  The command in **Case 1** will disable (git rm, commit and push) the profile out of the local repository. The default behaviour includes `git rm`, `commit` and `push`. To avoid that see `--no-commit`.

  - [x] **Case 2**: Disable the existing profile with no-commit
  ```
   $ ~/.wks/bin/wksctl profile disable \
        --repository=https://github.com/chanwit/podinfo-profile \
        --no-commit
  ```
  The command in **Case 2** will disable the profile out of the local repository by deleting files only. With `--no-commit` flag, it'll leave choices for users to manually commit and push codes.

**Note that** the profile must be in the form that could work out of the box with on-premises cluster. So that it's the responsibility of the profile owner to have it ready.

Fixes #82