### PR TITLE
Deprecate the `sshKeyPath` field of clusterapi Cluster, introduce `--ssh-key`

### DIFF
--- a/cmd/wksctl/apply/apply.go
+++ b/cmd/wksctl/apply/apply.go
@@ -9,6 +9,7 @@ import (
 	"github.com/weaveworks/wksctl/pkg/apis/wksprovider/machine/config"
 	wksos "github.com/weaveworks/wksctl/pkg/apis/wksprovider/machine/os"
 	"github.com/weaveworks/wksctl/pkg/manifests"
+	"github.com/weaveworks/wksctl/pkg/plan/runners/ssh"
 	"github.com/weaveworks/wksctl/pkg/specs"
 	"github.com/weaveworks/wksctl/pkg/utilities/kubeadm"
 	"github.com/weaveworks/wksctl/pkg/utilities/manifest"
@@ -94,7 +95,8 @@ func (a *Applier) Apply() error {
 
 func (a *Applier) initiateCluster(clusterManifestPath, machinesManifestPath string) error {
 	sp := specs.NewFromPaths(clusterManifestPath, machinesManifestPath)
-	sshClient, err := sp.GetSSHClient(a.Params.verbose)
+	sshClient, err := ssh.NewClientForMachine(sp.MasterSpec, sp.ClusterSpec.User, sp.ClusterSpec.SSHKeyPath, a.Params.verbose)
+
 	if err != nil {
 		return errors.Wrap(err, "failed to create SSH client")
 	}

--- a/cmd/wksctl/apply/apply.go
+++ b/cmd/wksctl/apply/apply.go
@@ -142,7 +142,7 @@ func (a *Applier) initiateCluster(clusterManifestPath, machinesManifestPath stri
 		PrivateIP:            sp.GetMasterPrivateAddress(),
 		ClusterManifestPath:  clusterManifestPath,
 		MachinesManifestPath: machinesManifestPath,
-		SSHKeyPath:           sp.GetSSHKeyPath(),
+		SSHKeyPath:           sp.ClusterSpec.SSHKeyPath,
 		BootstrapToken:       token,
 		KubeletConfig: config.KubeletConfig{
 			NodeIP:        sp.GetMasterPrivateAddress(),

--- a/cmd/wksctl/apply/apply.go
+++ b/cmd/wksctl/apply/apply.go
@@ -95,7 +95,7 @@ func (a *Applier) Apply() error {
 
 func (a *Applier) initiateCluster(clusterManifestPath, machinesManifestPath string) error {
 	sp := specs.NewFromPaths(clusterManifestPath, machinesManifestPath)
-	sshClient, err := ssh.NewClientForMachine(sp.MasterSpec, sp.ClusterSpec.User, sp.ClusterSpec.SSHKeyPath, a.Params.verbose)
+	sshClient, err := ssh.NewClientForMachine(sp.MasterSpec, sp.ClusterSpec.User, sp.ClusterSpec.DeprecatedSSHKeyPath, a.Params.verbose)
 
 	if err != nil {
 		return errors.Wrap(err, "failed to create SSH client")
@@ -142,7 +142,7 @@ func (a *Applier) initiateCluster(clusterManifestPath, machinesManifestPath stri
 		PrivateIP:            sp.GetMasterPrivateAddress(),
 		ClusterManifestPath:  clusterManifestPath,
 		MachinesManifestPath: machinesManifestPath,
-		SSHKeyPath:           sp.ClusterSpec.SSHKeyPath,
+		SSHKeyPath:           sp.ClusterSpec.DeprecatedSSHKeyPath,
 		BootstrapToken:       token,
 		KubeletConfig: config.KubeletConfig{
 			NodeIP:        sp.GetMasterPrivateAddress(),

--- a/cmd/wksctl/kubeconfig/kubeconfig.go
+++ b/cmd/wksctl/kubeconfig/kubeconfig.go
@@ -33,6 +33,7 @@ var kubeconfigOptions struct {
 	gitDeployKeyPath     string
 	artifactDirectory    string
 	namespace            string
+	sshKeyPath           string
 	skipTLSVerify        bool
 	useLocalhost         bool
 	usePublicAddress     bool
@@ -50,6 +51,7 @@ func init() {
 		"Branch within git repo containing your cluster and machine information")
 	Cmd.Flags().StringVar(&kubeconfigOptions.gitPath, "git-path", ".", "Relative path to files in Git")
 	Cmd.Flags().StringVar(&kubeconfigOptions.gitDeployKeyPath, "git-deploy-key", "", "Path to the Git deploy key")
+	Cmd.Flags().StringVar(&kubeconfigOptions.sshKeyPath, "ssh-key", "./cluster-key", "Path to a key authorized to log in to machines by SSH")
 	Cmd.Flags().StringVar(
 		&kubeconfigOptions.artifactDirectory, "artifact-directory", "", "Write output files in the specified directory")
 	Cmd.Flags().StringVar(
@@ -98,7 +100,7 @@ func writeKubeconfig(cpath, mpath string) error {
 	}
 	sp := specs.NewFromPaths(cpath, mpath)
 
-	configStr, err := config.GetRemoteKubeconfig(sp, kubeconfigOptions.verbose, kubeconfigOptions.skipTLSVerify)
+	configStr, err := config.GetRemoteKubeconfig(sp, kubeconfigOptions.sshKeyPath, kubeconfigOptions.verbose, kubeconfigOptions.skipTLSVerify)
 	if err != nil {
 		return errors.Wrapf(err, "GetRemoteKubeconfig")
 	}

--- a/cmd/wksctl/plan/view/view.go
+++ b/cmd/wksctl/plan/view/view.go
@@ -83,7 +83,7 @@ func planRun(cmd *cobra.Command, args []string) error {
 func displayPlan(clusterManifestPath, machinesManifestPath string) error {
 	// TODO: reuse the actual plan created by `wksctl apply`, rather than trying to construct a similar plan and printing it.
 	sp := specs.NewFromPaths(clusterManifestPath, machinesManifestPath)
-	sshClient, err := ssh.NewClientForMachine(sp.MasterSpec, sp.ClusterSpec.User, sp.ClusterSpec.SSHKeyPath, viewOptions.verbose)
+	sshClient, err := ssh.NewClientForMachine(sp.MasterSpec, sp.ClusterSpec.User, sp.ClusterSpec.DeprecatedSSHKeyPath, viewOptions.verbose)
 	if err != nil {
 		return errors.Wrap(err, "failed to create SSH client: ")
 	}
@@ -104,7 +104,7 @@ func displayPlan(clusterManifestPath, machinesManifestPath string) error {
 		PrivateIP:            sp.GetMasterPrivateAddress(),
 		ClusterManifestPath:  clusterManifestPath,
 		MachinesManifestPath: machinesManifestPath,
-		SSHKeyPath:           sp.ClusterSpec.SSHKeyPath,
+		SSHKeyPath:           sp.ClusterSpec.DeprecatedSSHKeyPath,
 		KubeletConfig: config.KubeletConfig{
 			NodeIP:        sp.GetMasterPrivateAddress(),
 			CloudProvider: sp.GetCloudProvider(),

--- a/cmd/wksctl/plan/view/view.go
+++ b/cmd/wksctl/plan/view/view.go
@@ -104,7 +104,7 @@ func displayPlan(clusterManifestPath, machinesManifestPath string) error {
 		PrivateIP:            sp.GetMasterPrivateAddress(),
 		ClusterManifestPath:  clusterManifestPath,
 		MachinesManifestPath: machinesManifestPath,
-		SSHKeyPath:           sp.GetSSHKeyPath(),
+		SSHKeyPath:           sp.ClusterSpec.SSHKeyPath,
 		KubeletConfig: config.KubeletConfig{
 			NodeIP:        sp.GetMasterPrivateAddress(),
 			CloudProvider: sp.GetCloudProvider(),

--- a/cmd/wksctl/plan/view/view.go
+++ b/cmd/wksctl/plan/view/view.go
@@ -32,6 +32,7 @@ var viewOptions struct {
 	gitBranch            string
 	gitPath              string
 	gitDeployKeyPath     string
+	sshKeyPath           string
 	sealedSecretCertPath string
 	configDirectory      string
 	verbose              bool
@@ -46,6 +47,7 @@ func init() {
 	Cmd.Flags().StringVar(&viewOptions.gitBranch, "git-branch", "master", "Git branch WKS should use to read your cluster")
 	Cmd.Flags().StringVar(&viewOptions.gitPath, "git-path", ".", "Relative path to files in Git")
 	Cmd.Flags().StringVar(&viewOptions.gitDeployKeyPath, "git-deploy-key", "", "Path to the Git deploy key")
+	Cmd.Flags().StringVar(&viewOptions.sshKeyPath, "ssh-key", "./cluster-key", "Path to a key authorized to log in to machines by SSH")
 	Cmd.Flags().StringVar(&viewOptions.sealedSecretCertPath, "sealed-secret-cert", "", "Path to a certificate used to encrypt sealed secrets")
 	Cmd.Flags().StringVar(&viewOptions.configDirectory, "config-directory", ".", "Directory containing configuration information for the cluster")
 
@@ -83,7 +85,7 @@ func planRun(cmd *cobra.Command, args []string) error {
 func displayPlan(clusterManifestPath, machinesManifestPath string) error {
 	// TODO: reuse the actual plan created by `wksctl apply`, rather than trying to construct a similar plan and printing it.
 	sp := specs.NewFromPaths(clusterManifestPath, machinesManifestPath)
-	sshClient, err := ssh.NewClientForMachine(sp.MasterSpec, sp.ClusterSpec.User, sp.ClusterSpec.DeprecatedSSHKeyPath, viewOptions.verbose)
+	sshClient, err := ssh.NewClientForMachine(sp.MasterSpec, sp.ClusterSpec.User, viewOptions.sshKeyPath, viewOptions.verbose)
 	if err != nil {
 		return errors.Wrap(err, "failed to create SSH client: ")
 	}
@@ -104,7 +106,7 @@ func displayPlan(clusterManifestPath, machinesManifestPath string) error {
 		PrivateIP:            sp.GetMasterPrivateAddress(),
 		ClusterManifestPath:  clusterManifestPath,
 		MachinesManifestPath: machinesManifestPath,
-		SSHKeyPath:           sp.ClusterSpec.DeprecatedSSHKeyPath,
+		SSHKeyPath:           viewOptions.sshKeyPath,
 		KubeletConfig: config.KubeletConfig{
 			NodeIP:        sp.GetMasterPrivateAddress(),
 			CloudProvider: sp.GetCloudProvider(),

--- a/cmd/wksctl/plan/view/view.go
+++ b/cmd/wksctl/plan/view/view.go
@@ -9,6 +9,7 @@ import (
 	"github.com/weaveworks/wksctl/pkg/apis/wksprovider/machine/config"
 	"github.com/weaveworks/wksctl/pkg/apis/wksprovider/machine/os"
 	"github.com/weaveworks/wksctl/pkg/manifests"
+	"github.com/weaveworks/wksctl/pkg/plan/runners/ssh"
 	"github.com/weaveworks/wksctl/pkg/specs"
 	"github.com/weaveworks/wksctl/pkg/utilities/manifest"
 	"github.com/weaveworks/wksctl/pkg/version"
@@ -82,7 +83,7 @@ func planRun(cmd *cobra.Command, args []string) error {
 func displayPlan(clusterManifestPath, machinesManifestPath string) error {
 	// TODO: reuse the actual plan created by `wksctl apply`, rather than trying to construct a similar plan and printing it.
 	sp := specs.NewFromPaths(clusterManifestPath, machinesManifestPath)
-	sshClient, err := sp.GetSSHClient(viewOptions.verbose)
+	sshClient, err := ssh.NewClientForMachine(sp.MasterSpec, sp.ClusterSpec.User, sp.ClusterSpec.SSHKeyPath, viewOptions.verbose)
 	if err != nil {
 		return errors.Wrap(err, "failed to create SSH client: ")
 	}

--- a/docs/wks-and-vagrant.md
+++ b/docs/wks-and-vagrant.md
@@ -4,7 +4,7 @@
 $ make install
 $ cd examples/vagrant
 $ vagrant up
-$ wksctl apply --cluster=cluster.yaml --machines=machines2.yaml
+$ wksctl apply --cluster=cluster.yaml --machines=machines2.yaml --ssh-key=$HOME/.vagrant/insecure_private_key
 INFO[0000] installing CRI implementation
 INFO[0054] installing Kubernetes
 INFO[0079] initializing Kubernetes cluster with kubeadm

--- a/examples/footloose/cluster.yaml
+++ b/examples/footloose/cluster.yaml
@@ -13,7 +13,6 @@ spec:
     value:
       apiVersion: baremetalproviderspec/v1alpha1
       kind: BareMetalClusterProviderSpec
-      sshKeyPath: cluster-key
       user: root
       os:
         files:

--- a/examples/gce/.gitignore
+++ b/examples/gce/.gitignore
@@ -1,8 +1,8 @@
 /instances.json
 /machines.yaml
-ssh_key
+cluster-key
+cluster-key.pub
 ssh_key.list
-ssh_key.pub
 .envrc
 git_deploy_key
 git_deploy_key.pub

--- a/examples/gce/cluster.yaml
+++ b/examples/gce/cluster.yaml
@@ -13,7 +13,6 @@ spec:
     value:
       apiVersion: baremetalproviderspec/v1alpha1
       kind: BareMetalClusterProviderSpec
-      sshKeyPath: ./ssh_key
       user: wks
       os:
         files:

--- a/examples/gce/create-instances.sh
+++ b/examples/gce/create-instances.sh
@@ -10,8 +10,8 @@ ensure_ssh_key() {
     ssh-keygen -q -t rsa -b 4096 -C "wks-dev@weave.works" -f $name -N ""
 }
 
-ensure_ssh_key ssh_key
-echo "wks:$(cat ./ssh_key.pub | awk '{print $1" "$2" wks"}')" > ssh_key.list
+ensure_ssh_key cluster-key
+echo "wks:$(cat ./cluster-key.pub | awk '{print $1" "$2" wks"}')" > ssh_key.list
 
 gcloud compute --project="${project}" instances create ${user}-wks-{1,2,3} \
   --network="${network}" \

--- a/examples/vagrant/cluster.yaml
+++ b/examples/vagrant/cluster.yaml
@@ -13,7 +13,6 @@ spec:
     value:
       apiVersion: baremetalproviderspec/v1alpha1
       kind: BareMetalClusterProviderSpec
-      sshKeyPath: ~/.vagrant.d/insecure_private_key
       user: vagrant
       os:
         files:

--- a/pkg/apis/wksprovider/controller/wksctl/machine_actuator.go
+++ b/pkg/apis/wksprovider/controller/wksctl/machine_actuator.go
@@ -150,11 +150,11 @@ func (a *MachineActuator) connectTo(c *baremetalspecv1.BareMetalClusterProviderS
 		return nil, nil, gerrors.Wrap(err, "failed to read SSH key")
 	}
 	sshClient, err := ssh.NewClient(ssh.ClientParams{
-		User:       c.User,
-		Host:       m.Private.Address,
-		Port:       m.Private.Port,
-		PrivateKey: sshKey,
-		Verbose:    a.verbose,
+		User:         c.User,
+		Host:         m.Private.Address,
+		Port:         m.Private.Port,
+		PrivateKey:   sshKey,
+		PrintOutputs: a.verbose,
 	})
 	if err != nil {
 		return nil, nil, gerrors.Wrapf(err, "failed to create SSH client using %v", m.Private)

--- a/pkg/baremetalproviderspec/types.go
+++ b/pkg/baremetalproviderspec/types.go
@@ -8,9 +8,9 @@ import (
 type BareMetalClusterProviderSpec struct {
 	metav1.TypeMeta `json:",inline"`
 
-	User       string `json:"user"`
-	SSHKeyPath string `json:"sshKeyPath"`
-	HTTPProxy  string `json:"httpProxy,omitempty"`
+	User                 string `json:"user"`
+	DeprecatedSSHKeyPath string `json:"sshKeyPath"`
+	HTTPProxy            string `json:"httpProxy,omitempty"`
 
 	Authentication *AuthenticationWebhook `json:"authenticationWebhook,omitempty"`
 	Authorization  *AuthorizationWebhook  `json:"authorizationWebhook,omitempty"`

--- a/pkg/baremetalproviderspec/v1alpha1/types.go
+++ b/pkg/baremetalproviderspec/v1alpha1/types.go
@@ -8,9 +8,9 @@ import (
 type BareMetalClusterProviderSpec struct {
 	metav1.TypeMeta `json:",inline"`
 
-	User       string `json:"user"`
-	SSHKeyPath string `json:"sshKeyPath"`
-	HTTPProxy  string `json:"httpProxy,omitempty"`
+	User                 string `json:"user"`
+	DeprecatedSSHKeyPath string `json:"sshKeyPath"`
+	HTTPProxy            string `json:"httpProxy,omitempty"`
 
 	Authentication *AuthenticationWebhook `json:"authenticationWebhook,omitempty"`
 	Authorization  *AuthorizationWebhook  `json:"authorizationWebhook,omitempty"`

--- a/pkg/kubernetes/config/kubeconfig.go
+++ b/pkg/kubernetes/config/kubeconfig.go
@@ -8,6 +8,7 @@ import (
 	yaml "github.com/ghodss/yaml"
 	"github.com/pkg/errors"
 	"github.com/weaveworks/wksctl/pkg/cluster/machine"
+	"github.com/weaveworks/wksctl/pkg/plan/runners/ssh"
 	"github.com/weaveworks/wksctl/pkg/plan/runners/sudo"
 	"github.com/weaveworks/wksctl/pkg/specs"
 	"github.com/weaveworks/wksctl/pkg/utilities/path"
@@ -76,7 +77,7 @@ func Sanitize(configStr string, params Params) (string, error) {
 }
 
 func GetRemoteKubeconfig(sp *specs.Specs, verbose, skipTLSVerify bool) (string, error) {
-	sshClient, err := sp.GetSSHClient(verbose)
+	sshClient, err := ssh.NewClientForMachine(sp.MasterSpec, sp.ClusterSpec.User, sp.ClusterSpec.SSHKeyPath, verbose)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to create SSH client: ")
 	}

--- a/pkg/kubernetes/config/kubeconfig.go
+++ b/pkg/kubernetes/config/kubeconfig.go
@@ -76,8 +76,8 @@ func Sanitize(configStr string, params Params) (string, error) {
 	return configStr, nil
 }
 
-func GetRemoteKubeconfig(sp *specs.Specs, verbose, skipTLSVerify bool) (string, error) {
-	sshClient, err := ssh.NewClientForMachine(sp.MasterSpec, sp.ClusterSpec.User, sp.ClusterSpec.DeprecatedSSHKeyPath, verbose)
+func GetRemoteKubeconfig(sp *specs.Specs, sshKeyPath string, verbose, skipTLSVerify bool) (string, error) {
+	sshClient, err := ssh.NewClientForMachine(sp.MasterSpec, sp.ClusterSpec.User, sshKeyPath, verbose)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to create SSH client: ")
 	}

--- a/pkg/kubernetes/config/kubeconfig.go
+++ b/pkg/kubernetes/config/kubeconfig.go
@@ -77,7 +77,7 @@ func Sanitize(configStr string, params Params) (string, error) {
 }
 
 func GetRemoteKubeconfig(sp *specs.Specs, verbose, skipTLSVerify bool) (string, error) {
-	sshClient, err := ssh.NewClientForMachine(sp.MasterSpec, sp.ClusterSpec.User, sp.ClusterSpec.SSHKeyPath, verbose)
+	sshClient, err := ssh.NewClientForMachine(sp.MasterSpec, sp.ClusterSpec.User, sp.ClusterSpec.DeprecatedSSHKeyPath, verbose)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to create SSH client: ")
 	}

--- a/pkg/plan/runners/ssh/ssh.go
+++ b/pkg/plan/runners/ssh/ssh.go
@@ -21,14 +21,14 @@ type ClientParams struct {
 	Port           uint16
 	PrivateKeyPath string
 	PrivateKey     []byte
-	Verbose        bool
+	PrintOutputs   bool
 }
 
 // Client is a higher-level abstraction around the standard API's SSH
 // configuration, client and connection to the remote machine.
 type Client struct {
-	client  *ssh.Client
-	verbose bool
+	client       *ssh.Client
+	printOutputs bool
 }
 
 var _ plan.Runner = &Client{}
@@ -38,7 +38,7 @@ const tcp = "tcp"
 // NewClient instantiates a new SSH Client object.
 // N.B.: provide either the key (privateKey) or its path (privateKeyPath).
 func NewClient(params ClientParams) (*Client, error) {
-	log.WithFields(log.Fields{"user": params.User, "host": params.Host, "port": params.Port, "privateKeyPath": params.PrivateKeyPath, "verbose": params.Verbose}).Debugf("creating SSH client")
+	log.WithFields(log.Fields{"user": params.User, "host": params.Host, "port": params.Port, "privateKeyPath": params.PrivateKeyPath, "printOutputs": params.PrintOutputs}).Debugf("creating SSH client")
 	signer, err := sshutil.SignerFromPrivateKey(params.PrivateKeyPath, params.PrivateKey)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to read private key from \"%s\"", params.PrivateKeyPath)
@@ -60,8 +60,8 @@ func NewClient(params ClientParams) (*Client, error) {
 		return nil, errors.Wrapf(err, "failed to connect to %s", hostPort)
 	}
 	return &Client{
-		client:  client,
-		verbose: params.Verbose,
+		client:       client,
+		printOutputs: params.PrintOutputs,
 	}, nil
 }
 
@@ -96,7 +96,7 @@ func (c *Client) handleSessionIO(action func(*ssh.Session) error) (string, error
 	var stdOutErr bytes.Buffer
 	outWriters := []io.Writer{&stdOutErr}
 	errWriters := []io.Writer{&stdOutErr}
-	if c.verbose {
+	if c.printOutputs {
 		outWriters = append(outWriters, os.Stdout)
 		errWriters = append(errWriters, os.Stderr)
 	}

--- a/pkg/plan/runners/ssh/ssh.go
+++ b/pkg/plan/runners/ssh/ssh.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
+	"github.com/weaveworks/wksctl/pkg/baremetalproviderspec/v1alpha1"
 	"github.com/weaveworks/wksctl/pkg/plan"
 	sshutil "github.com/weaveworks/wksctl/pkg/utilities/ssh"
 	"golang.org/x/crypto/ssh"
@@ -34,6 +35,26 @@ type Client struct {
 var _ plan.Runner = &Client{}
 
 const tcp = "tcp"
+
+func NewClientForMachine(m *v1alpha1.BareMetalMachineProviderSpec, user, keyPath string, printOutputs bool) (*Client, error) {
+	var ip string
+	var port uint16
+	if m.Public.Address != "" {
+		ip = m.Public.Address
+		port = m.Public.Port
+	} else {
+		// Fall back to the address at the root
+		ip = m.Address
+		port = m.Port
+	}
+	return NewClient(ClientParams{
+		User:           user,
+		Host:           ip,
+		Port:           port,
+		PrivateKeyPath: keyPath,
+		PrintOutputs:   printOutputs,
+	})
+}
 
 // NewClient instantiates a new SSH Client object.
 // N.B.: provide either the key (privateKey) or its path (privateKeyPath).

--- a/pkg/specs/specs.go
+++ b/pkg/specs/specs.go
@@ -127,10 +127,6 @@ func parseClusterManifest(file string) (*clusterv1.Cluster, error) {
 }
 
 // Getters for nested fields needed externally
-func (s *Specs) GetSSHKeyPath() string {
-	return s.ClusterSpec.SSHKeyPath
-}
-
 func (s *Specs) GetClusterName() string {
 	return s.cluster.ObjectMeta.Name
 }

--- a/pkg/specs/specs.go
+++ b/pkg/specs/specs.go
@@ -71,7 +71,7 @@ func New(cluster *clusterv1.Cluster, machines []*clusterv1.Machine) *Specs {
 }
 
 // Create an SSHClient to the master node referenced by the specs
-func (s *Specs) GetSSHClient(verbose bool) (*ssh.Client, error) {
+func (s *Specs) GetSSHClient(printOutputs bool) (*ssh.Client, error) {
 	var ip string
 	var port uint16
 	if s.masterSpec.Public.Address != "" {
@@ -87,7 +87,7 @@ func (s *Specs) GetSSHClient(verbose bool) (*ssh.Client, error) {
 		Host:           ip,
 		Port:           port,
 		PrivateKeyPath: s.ClusterSpec.SSHKeyPath,
-		Verbose:        verbose,
+		PrintOutputs:   printOutputs,
 	})
 }
 

--- a/pkg/specs/specs.go
+++ b/pkg/specs/specs.go
@@ -9,7 +9,6 @@ import (
 	log "github.com/sirupsen/logrus"
 	baremetalspecv1 "github.com/weaveworks/wksctl/pkg/baremetalproviderspec/v1alpha1"
 	"github.com/weaveworks/wksctl/pkg/cluster/machine"
-	"github.com/weaveworks/wksctl/pkg/plan/runners/ssh"
 	"github.com/weaveworks/wksctl/pkg/utilities"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
@@ -22,7 +21,7 @@ import (
 type Specs struct {
 	cluster      *clusterv1.Cluster
 	ClusterSpec  *baremetalspecv1.BareMetalClusterProviderSpec
-	masterSpec   *baremetalspecv1.BareMetalMachineProviderSpec
+	MasterSpec   *baremetalspecv1.BareMetalMachineProviderSpec
 	machineCount int
 	masterCount  int
 }
@@ -63,32 +62,11 @@ func New(cluster *clusterv1.Cluster, machines []*clusterv1.Machine) *Specs {
 	return &Specs{
 		cluster:     cluster,
 		ClusterSpec: clusterSpec,
-		masterSpec:  masterSpec,
+		MasterSpec:  masterSpec,
 
 		machineCount: len(machines),
 		masterCount:  masterCount,
 	}
-}
-
-// Create an SSHClient to the master node referenced by the specs
-func (s *Specs) GetSSHClient(printOutputs bool) (*ssh.Client, error) {
-	var ip string
-	var port uint16
-	if s.masterSpec.Public.Address != "" {
-		ip = s.masterSpec.Public.Address
-		port = s.masterSpec.Public.Port
-	} else {
-		// Fall back to the address at the root
-		ip = s.masterSpec.Address
-		port = s.masterSpec.Port
-	}
-	return ssh.NewClient(ssh.ClientParams{
-		User:           s.ClusterSpec.User,
-		Host:           ip,
-		Port:           port,
-		PrivateKeyPath: s.ClusterSpec.SSHKeyPath,
-		PrintOutputs:   printOutputs,
-	})
 }
 
 func parseManifests(clusterManifestPath, machinesManifestPath string) (*clusterv1.Cluster, []*clusterv1.Machine, error) {
@@ -158,11 +136,11 @@ func (s *Specs) GetClusterName() string {
 }
 
 func (s *Specs) GetMasterPublicAddress() string {
-	return s.masterSpec.Public.Address
+	return s.MasterSpec.Public.Address
 }
 
 func (s *Specs) GetMasterPrivateAddress() string {
-	return s.masterSpec.Private.Address
+	return s.MasterSpec.Private.Address
 }
 
 func (s *Specs) GetCloudProvider() string {

--- a/pkg/specs/validation.go
+++ b/pkg/specs/validation.go
@@ -5,15 +5,12 @@ import (
 	"net"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 
-	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/weaveworks/launcher/pkg/kubectl"
 	"github.com/weaveworks/wksctl/pkg/addons"
 	baremetalspecv1 "github.com/weaveworks/wksctl/pkg/baremetalproviderspec/v1alpha1"
-	"github.com/weaveworks/wksctl/pkg/utilities/path"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 )
@@ -67,28 +64,6 @@ func updateClusterProviderSpec(cluster *clusterv1.Cluster, updateFunc func(spec 
 		log.Fatal("error encoding spec: ", err)
 	}
 	cluster.Spec.ProviderSpec = *encodedSpec
-}
-
-func resolveFilePath(filePath string) (string, error) {
-	if strings.HasPrefix(filePath, "~/") {
-		home, err := path.UserHomeDirectory()
-		if err != nil {
-			return "", errors.Wrap(err, "error getting home directory")
-		}
-		return filepath.Join(home, filePath[2:]), nil
-	}
-
-	return filepath.Abs(filePath)
-}
-
-func expandSSHKeyPath(cluster *clusterv1.Cluster) {
-	updateClusterProviderSpec(cluster, func(spec *baremetalspecv1.BareMetalClusterProviderSpec) {
-		sshKeyPath, err := resolveFilePath(spec.SSHKeyPath)
-		if err != nil {
-			log.WithError(err).Fatalf("Failed to resolve sshKeyPath")
-		}
-		spec.SSHKeyPath = sshKeyPath
-	})
 }
 
 type clusterValidationFunc func(*clusterv1.Cluster, string) field.ErrorList
@@ -185,17 +160,17 @@ func fileExists(s string) bool {
 	return err == nil
 }
 
-func validateSSHKey(cluster *clusterv1.Cluster, manifestPath string) field.ErrorList {
+func validateSSHKeyEmpty(cluster *clusterv1.Cluster, manifestPath string) field.ErrorList {
 	spec, err := clusterSpec(cluster)
 	if err != nil {
 		log.Fatalf("Failed to parse the ClusterSpec -  %v", err)
 	}
-	f := spec.SSHKeyPath
-	if !fileExists(f) {
+
+	if spec.SSHKeyPath != "" {
 		return field.ErrorList{
 			field.Invalid(
-				clusterProviderPath("sshKeyPath"), f,
-				fmt.Sprintf("could not stat file: \"%s\"", f),
+				clusterProviderPath("sshKeyPath"), spec.SSHKeyPath,
+				"wks no longer expects the ssh key to be specified in the Cluster manifest - pleae provide the ssh key using CLI flags instead",
 			),
 		}
 	}
@@ -256,7 +231,6 @@ func validateAddons(cluster *clusterv1.Cluster, manifestPath string) field.Error
 //   - expand ~ and resolve relative path in SSH key path
 func populateCluster(cluster *clusterv1.Cluster) {
 	populateNetwork(cluster)
-	expandSSHKeyPath(cluster)
 }
 
 func validateCluster(cluster *clusterv1.Cluster, manifestPath string) field.ErrorList {
@@ -265,7 +239,7 @@ func validateCluster(cluster *clusterv1.Cluster, manifestPath string) field.Erro
 	for _, f := range []clusterValidationFunc{
 		validateCIDRBlocks,
 		validateServiceDomain,
-		validateSSHKey,
+		validateSSHKeyEmpty,
 		validateAddons,
 	} {
 		errors = append(errors, f(cluster, manifestPath)...)

--- a/pkg/specs/validation.go
+++ b/pkg/specs/validation.go
@@ -166,10 +166,10 @@ func validateSSHKeyEmpty(cluster *clusterv1.Cluster, manifestPath string) field.
 		log.Fatalf("Failed to parse the ClusterSpec -  %v", err)
 	}
 
-	if spec.SSHKeyPath != "" {
+	if spec.DeprecatedSSHKeyPath != "" {
 		return field.ErrorList{
 			field.Invalid(
-				clusterProviderPath("sshKeyPath"), spec.SSHKeyPath,
+				clusterProviderPath("sshKeyPath"), spec.DeprecatedSSHKeyPath,
 				"wks no longer expects the ssh key to be specified in the Cluster manifest - pleae provide the ssh key using CLI flags instead",
 			),
 		}

--- a/test/container/testutils/test_utils.go
+++ b/test/container/testutils/test_utils.go
@@ -121,7 +121,7 @@ func (r *FootlooseRunner) makeSSHClientWithRetries(numRetries int) (*ssh.Client,
 			Host:           host,
 			Port:           r.SSHPort,
 			PrivateKeyPath: r.sshPrivateKeyPath(),
-			Verbose:        true,
+			PrintOutputs:   true,
 		})
 
 		if err == nil {

--- a/test/integration/container/multimaster_test.go
+++ b/test/integration/container/multimaster_test.go
@@ -34,7 +34,6 @@ spec:
     value:
       apiVersion: baremetalproviderspec/v1alpha1
       kind: BareMetalClusterProviderSpec
-      sshKeyPath: cluster-key
       user: root
       imageRepository: %s:%d
       os:

--- a/test/integration/test/apply_test.go
+++ b/test/integration/test/apply_test.go
@@ -406,7 +406,7 @@ func TestApply(t *testing.T) {
 		Host:           ip,
 		Port:           port,
 		PrivateKeyPath: cSpec.SSHKeyPath,
-		Verbose:        true,
+		PrintOutputs:   true,
 	})
 	assert.NoError(t, err)
 	err = writeTmpFile(sshClient, "/tmp/workspace/cmd/mock-https-authz-server/server", "authserver")

--- a/test/integration/test/apply_test.go
+++ b/test/integration/test/apply_test.go
@@ -34,8 +34,9 @@ import (
 type role = string
 
 const (
-	master = "master"
-	node   = "node"
+	master     = "master"
+	node       = "node"
+	sshKeyPath = "/root/.ssh/wksctl_cit_id_rsa"
 )
 
 var (
@@ -405,7 +406,7 @@ func TestApply(t *testing.T) {
 		User:           cSpec.User,
 		Host:           ip,
 		Port:           port,
-		PrivateKeyPath: cSpec.SSHKeyPath,
+		PrivateKeyPath: sshKeyPath,
 		PrintOutputs:   true,
 	})
 	assert.NoError(t, err)
@@ -425,12 +426,12 @@ func TestApply(t *testing.T) {
 	// Install the Cluster.
 	run, err := apply(exe, "--cluster="+clusterManifestPath, "--machines="+machinesManifestPath, "--namespace=default",
 		"--config-directory="+configDir, "--sealed-secret-key="+configPath("ss.key"), "--sealed-secret-cert="+configPath("ss.cert"),
-		"--verbose=true")
+		"--verbose=true", "--ssh-key="+sshKeyPath)
 	assert.NoError(t, err)
 	assert.Equal(t, 0, run.ExitCode())
 
 	// Extract the kubeconfig,
-	run, err = kubeconfig(exe, "--cluster="+configPath("cluster.yaml"), "--machines="+configPath("machines.yaml"), "--namespace=default")
+	run, err = kubeconfig(exe, "--cluster="+configPath("cluster.yaml"), "--machines="+configPath("machines.yaml"), "--namespace=default", "--ssh-key="+sshKeyPath)
 	assert.NoError(t, err)
 	assert.Equal(t, 0, run.ExitCode())
 

--- a/test/integration/test/assets/cluster.yaml
+++ b/test/integration/test/assets/cluster.yaml
@@ -13,7 +13,6 @@ spec:
     value:
       apiVersion: "baremetalproviderspec/v1alpha1"
       kind: "BareMetalClusterProviderSpec"
-      sshKeyPath: "/root/.ssh/wksctl_cit_id_rsa"
       user: "wksctl-cit"
       os:
         files:


### PR DESCRIPTION
`sshKeyPath` is a field of the `Cluster` object that is interpreted by `wksctl` to be a local (CWD-relative) path to an SSH key. This location depends only on where the user of `wksctl` has the key on their local FS (likely put there by an infrastructure provisioning mechanism distributed as one of our examples) and needed only on invocation of `wksctl`, so it makes much more sense as a commandline flag than as a `Cluster` configuration parameter.

This PR:
- leaves the `sshKeyPath` field in `v1alpha1` `baremetalproviderspec` `Cluster` (so as not to break the existing schema). Renames the field in the Go model: `SSHKeyPath` -> `DeprecatedSSHKeyPath` to prevent accidental use.
- makes the specs validator return error if `sshKeyPath` is not empty
- introduces the `--ssh-key` flag that accepts the SSH key
- renames the `Verbose` field in our SSH runner to `PrintOutputs` to better reflect what it does