### PR TITLE
fix display error messages twice

### DIFF
--- a/cmd/wksctl/profile/disable/disable.go
+++ b/cmd/wksctl/profile/disable/disable.go
@@ -12,6 +12,7 @@ import (
 	"github.com/weaveworks/wksctl/pkg/git"
 )
 
+// Cmd is profile disable command
 var Cmd = &cobra.Command{
 	Use:   "disable",
 	Short: "disable profile",
@@ -32,7 +33,7 @@ Please make sure that there is no staged change on the current branch before dis
 }
 
 type profileDisableFlags struct {
-	gitUrl     string
+	gitURL     string
 	push       bool
 	profileDir string
 }
@@ -41,7 +42,7 @@ var profileDisableParams profileDisableFlags
 
 func init() {
 	Cmd.Flags().StringVar(&profileDisableParams.profileDir, "profile-dir", "profiles", "specify a directory for storing profiles")
-	Cmd.Flags().StringVar(&profileDisableParams.gitUrl, "git-url", "", "disable profile from the Git URL")
+	Cmd.Flags().StringVar(&profileDisableParams.gitURL, "git-url", "", "disable profile from the Git URL")
 	Cmd.Flags().BoolVar(&profileDisableParams.push, "push", true, "auto push after disable the profile")
 }
 
@@ -53,16 +54,16 @@ func profileDisableArgs(cmd *cobra.Command, args []string) error {
 }
 
 func profileDisable(params profileDisableFlags) error {
-	repoUrl := params.gitUrl
-	if repoUrl == constants.AppDevAlias {
-		repoUrl = constants.AppDevRepoURL
+	repoURL := params.gitURL
+	if repoURL == constants.AppDevAlias {
+		repoURL = constants.AppDevRepoURL
 	}
 
-	if err := git.IsGitURL(repoUrl); err != nil {
+	if err := git.IsGitURL(repoURL); err != nil {
 		return err
 	}
 
-	hostName, repoName, err := git.HostAndRepoPath(repoUrl)
+	hostName, repoName, err := git.HostAndRepoPath(repoURL)
 	if err != nil {
 		return err
 	}

--- a/cmd/wksctl/profile/disable/disable.go
+++ b/cmd/wksctl/profile/disable/disable.go
@@ -22,8 +22,11 @@ wksctl profile disable --git-url=<profile_repository> [--revision=master] [--pus
 Please make sure that there is no staged change on the current branch before disable a profile.
 `,
 	Args: profileDisableArgs,
-	RunE: func(_ *cobra.Command, _ []string) error {
-		return profileDisable(profileDisableParams)
+	Run: func(_ *cobra.Command, _ []string) {
+		err := profileDisable(profileDisableParams)
+		if err != nil {
+			log.Fatal(err)
+		}
 	},
 	SilenceUsage: true,
 }
@@ -38,7 +41,7 @@ var profileDisableParams profileDisableFlags
 
 func init() {
 	Cmd.Flags().StringVar(&profileDisableParams.profileDir, "profile-dir", "profiles", "specify a directory for storing profiles")
-	Cmd.Flags().StringVar(&profileDisableParams.gitUrl, "git-url", "", "enable profile from the Git URL")
+	Cmd.Flags().StringVar(&profileDisableParams.gitUrl, "git-url", "", "disable profile from the Git URL")
 	Cmd.Flags().BoolVar(&profileDisableParams.push, "push", true, "auto push after disable the profile")
 }
 

--- a/cmd/wksctl/profile/enable/enable.go
+++ b/cmd/wksctl/profile/enable/enable.go
@@ -21,8 +21,11 @@ If you'd like to specify the revision other than the master branch, use --revisi
 To disable auto-push, pass --push=false.
 `,
 	Args: profileEnableArgs,
-	RunE: func(_ *cobra.Command, _ []string) error {
-		return profileEnableRun(profileEnableParams)
+	Run: func(_ *cobra.Command, _ []string) {
+		err := profileEnableRun(profileEnableParams)
+		if err != nil {
+			log.Fatal(err)
+		}
 	},
 	SilenceUsage: true,
 }

--- a/cmd/wksctl/profile/enable/enable.go
+++ b/cmd/wksctl/profile/enable/enable.go
@@ -10,6 +10,7 @@ import (
 	"github.com/weaveworks/wksctl/pkg/git"
 )
 
+// Cmd is the command for profile enable
 var Cmd = &cobra.Command{
 	Use:   "enable",
 	Short: "Enable profile",
@@ -31,7 +32,7 @@ To disable auto-push, pass --push=false.
 }
 
 type profileEnableFlags struct {
-	gitUrl     string
+	gitURL     string
 	revision   string
 	push       bool
 	profileDir string
@@ -41,7 +42,7 @@ var profileEnableParams profileEnableFlags
 
 func init() {
 	Cmd.Flags().StringVar(&profileEnableParams.profileDir, "profile-dir", "profiles", "specify a directory for storing profiles")
-	Cmd.Flags().StringVar(&profileEnableParams.gitUrl, "git-url", "", "enable profile from the gitUrl")
+	Cmd.Flags().StringVar(&profileEnableParams.gitURL, "git-url", "", "enable profile from the gitUrl")
 	Cmd.Flags().StringVar(&profileEnableParams.revision, "revision", "master", "use this revision of the profile")
 	Cmd.Flags().BoolVar(&profileEnableParams.push, "push", true, "auto push after enable the profile")
 }
@@ -54,24 +55,24 @@ func profileEnableArgs(cmd *cobra.Command, args []string) error {
 }
 
 func profileEnableRun(params profileEnableFlags) error {
-	repoUrl := params.gitUrl
+	repoURL := params.gitURL
 
-	if repoUrl == constants.AppDevAlias {
-		repoUrl = constants.AppDevRepoURL
+	if repoURL == constants.AppDevAlias {
+		repoURL = constants.AppDevRepoURL
 	}
 
-	if err := git.IsGitURL(repoUrl); err != nil {
+	if err := git.IsGitURL(repoURL); err != nil {
 		return err
 	}
 
-	hostName, repoName, err := git.HostAndRepoPath(repoUrl)
+	hostName, repoName, err := git.HostAndRepoPath(repoURL)
 	if err != nil {
 		return err
 	}
 	clonePath := path.Join(params.profileDir, hostName, repoName)
 
 	log.Info("Adding the profile to the local repository...")
-	err = git.SubtreeAdd(clonePath, repoUrl, params.revision)
+	err = git.SubtreeAdd(clonePath, repoURL, params.revision)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR fixes a small behaviour of `wksctl profile enable/disable` that display error messages twice. This is because the use of `RunE` rather than `Run`.
Other `wksctl` commands use `Run` and display error messages via `log.Fatal`.
