### PR TITLE
implement file ignore in the profile enable process

### DIFF
--- a/cmd/wksctl/profile/constants/constants.go
+++ b/cmd/wksctl/profile/constants/constants.go
@@ -3,4 +3,7 @@ package constants
 const (
 	AppDevAlias   = "app-dev"
 	AppDevRepoURL = "git@github.com:weaveworks/eks-quickstart-app-dev"
+
+	// WKSctlIgnoreFilename is the ignore file recognized by wksctl
+	WKSctlIgnoreFilename = ".wksctlignore"
 )

--- a/cmd/wksctl/profile/enable/enable_test.go
+++ b/cmd/wksctl/profile/enable/enable_test.go
@@ -1,0 +1,45 @@
+package enable
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	ignoreFileFixture = `a
+b/
+ #c
+#d
+e
+f
+../g
+h..
+i # this is i
+ j/# this is j
+`
+)
+
+func TestParseDotIgnoreFile(t *testing.T) {
+	r := strings.NewReader(ignoreFileFixture)
+	lines, err := parseDotIgnorefile("", r)
+	assert.NoError(t, err, "parsing ignore file should not be error")
+	assert.Equal(t, 8, len(lines), "ignore file entries should be 8")
+	// Entry: 'b/' is resolved to 'b' by path.Join()
+	assert.Equal(t, []string{"a", "b", "e", "f", "../g", "h..", "i", "j"}, lines)
+}
+
+func TestParseDotIgnoreFileWithPrefix(t *testing.T) {
+	r := strings.NewReader(ignoreFileFixture)
+	lines, err := parseDotIgnorefile("profiles", r)
+	assert.NoError(t, err, "parsing ignore file should not be error")
+	assert.Equal(t, 8, len(lines), "ignore file entries should be 8")
+	// Note:
+	// - 'profiles/b/' is resolved to 'profiles/b'
+	// - 'profiles/../g' is resolved to 'g'
+	assert.Equal(t, []string{
+		"profiles/a", "profiles/b", "profiles/e",
+		"profiles/f", "g", "profiles/h..",
+		"profiles/i", "profiles/j"}, lines)
+}

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -22,8 +22,8 @@ func HasNoStagedChanges() error {
 	return errors.Wrap(gitExec("diff", "--staged", "--exit-code"), "repository contains staged changes")
 }
 
-func RmRecursive(path string) error {
-	return gitExec("rm", "-r", "--", path)
+func RmRecursive(paths ...string) error {
+	return gitExec(append([]string{"rm", "-r", "--"}, paths...)...)
 }
 
 func AddAll(path string) error {


### PR DESCRIPTION
This PR makes the `profile enable` command to uses contents of the `.wksctlignore` file, if exists on the top most directory of the profile, to filter out unneeded files.

What does this PR do:
1. detect `.wksctlignore` at the top level directory of the profile.
2. use each line of the `.wksctlignore` file to do `git rm`.
3. amend the previous commit (done by `git subtree add`)

A test case to test the processing of `.wksctlignore` is included.