### PR TITLE
add --with-helm option for profile enable

### DIFF
--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -19,7 +19,7 @@ func gitExec(args ...string) error {
 }
 
 func HasNoStagedChanges() error {
-	return errors.Wrap(gitExec("diff", "--staged", "--exit-code"), "repository contains staged changes")
+	return errors.Wrap(gitExec("diff", "--quiet", "--staged", "--exit-code"), "repository contains staged changes")
 }
 
 func RmRecursive(paths ...string) error {


### PR DESCRIPTION
This PR adds `--with-helm` to the command `wksctl profile enable`.
It is the counterpart of the EKSctl `profile enable` behaviour.
Flux Helm Operator + CRD are required as the EKS quickstart app-test profile contains a `HelmRelese` resource. To make EKSctl profiles consumable by WKSctl and Firekube, we need the operator to be properly installed.

The default value of the flag is `true` meaning that this command always try to install Flux Helm Operator unless `--with-helm=false` is specified.

The location of Flux Helm Operator manifest will be placed at `base/addons/flux-helm-op/flux-helm-op.yaml`. Then `git add` and `git commit` with the message saying that it is installed.
