### PR TITLE
Kubeadm 1.16 support

### DIFF
--- a/pkg/apis/wksprovider/controller/wksctl/machine_actuator.go
+++ b/pkg/apis/wksprovider/controller/wksctl/machine_actuator.go
@@ -508,7 +508,7 @@ func (a *MachineActuator) kubeadmUpOrDowngrade(machine *clusterv1.Machine, node 
 	case secondaryMaster:
 		b.AddResource(
 			"upgrade:node-kubeadm-upgrade",
-			&resource.Run{Script: object.String("kubeadm upgrade node experimental-control-plane")},
+			&resource.Run{Script: object.String("kubeadm upgrade node")},
 			plan.DependOn("upgrade:node-install-kubeadm"))
 	case worker:
 		b.AddResource(


### PR DESCRIPTION
* Currently k8s 1.16 upgrade breaks for secondary masters. Dropping the command allows us to support both 1.14 and above. So it's backwards compatible