### PR TITLE
Fix SELinux permissive mode detection logic

### DIFF
--- a/pkg/apis/wksprovider/controller/wksctl/machine_actuator.go
+++ b/pkg/apis/wksprovider/controller/wksctl/machine_actuator.go
@@ -433,7 +433,7 @@ func (a *MachineActuator) update(ctx context.Context, cluster *clusterv1.Cluster
 
 	if diffedPlan, err := plandiff.GetUnifiedDiff(currentPlan, planJSON); err == nil {
 		contextLog.Info("........................ DIFF PLAN ........................")
-		contextLog.Info(diffedPlan)
+		fmt.Print(diffedPlan)
 	} else {
 		contextLog.Errorf("DIFF PLAN Error: %v", err)
 	}

--- a/pkg/apis/wksprovider/machine/os/os.go
+++ b/pkg/apis/wksprovider/machine/os/os.go
@@ -244,7 +244,7 @@ func (o OS) CreateSeedNodeSetupPlan(params SeedNodeParams) (*plan.Plan, error) {
 	criRes := recipe.BuildCRIPlan(&providerSpec.CRI, cfg, o.PkgType)
 	b.AddResource("install:cri", criRes, plan.DependOn("install:config"))
 
-	k8sRes := recipe.BuildK8SPlan(kubernetesVersion, params.KubeletConfig.NodeIP, cfg.SetSELinuxPermissive, cfg.DisableSwap, cfg.LockYUMPkgs, o.PkgType, params.KubeletConfig.CloudProvider)
+	k8sRes := recipe.BuildK8SPlan(kubernetesVersion, params.KubeletConfig.NodeIP, cfg.SELinuxInstalled, cfg.SetSELinuxPermissive, cfg.DisableSwap, cfg.LockYUMPkgs, o.PkgType, params.KubeletConfig.CloudProvider)
 	b.AddResource("install:k8s", k8sRes, plan.DependOn("install:cri"))
 
 	apiServerArgs := getAPIServerArgs(providerSpec, pemSecretResources)
@@ -1041,7 +1041,7 @@ func (o OS) CreateNodeSetupPlan(params NodeParams) (*plan.Plan, error) {
 	instCriRsrc := recipe.BuildCRIPlan(&params.CRI, cfg, o.PkgType)
 	b.AddResource("install.cri", instCriRsrc, plan.DependOn("install:config"))
 
-	instK8sRsrc := recipe.BuildK8SPlan(params.KubernetesVersion, params.KubeletConfig.NodeIP, cfg.SetSELinuxPermissive, cfg.DisableSwap, cfg.LockYUMPkgs, o.PkgType, params.KubeletConfig.CloudProvider)
+	instK8sRsrc := recipe.BuildK8SPlan(params.KubernetesVersion, params.KubeletConfig.NodeIP, cfg.SELinuxInstalled, cfg.SetSELinuxPermissive, cfg.DisableSwap, cfg.LockYUMPkgs, o.PkgType, params.KubeletConfig.CloudProvider)
 
 	b.AddResource("install:k8s", instK8sRsrc, plan.DependOn("install.cri"))
 

--- a/pkg/plan/recipe/install_plans.go
+++ b/pkg/plan/recipe/install_plans.go
@@ -150,7 +150,7 @@ ExecStartPre=-/sbin/swapoff -a
 `
 
 // BuildK8SPlan creates a plan for running kubernetes on a node
-func BuildK8SPlan(kubernetesVersion string, kubeletNodeIP string, setSELinuxPermissive, disableSwap, lockYUMPkgs bool, pkgType resource.PkgType, cloudProvider string) plan.Resource {
+func BuildK8SPlan(kubernetesVersion string, kubeletNodeIP string, seLinuxInstalled, setSELinuxPermissive, disableSwap, lockYUMPkgs bool, pkgType resource.PkgType, cloudProvider string) plan.Resource {
 	b := plan.NewBuilder()
 
 	// Kubernetes repos
@@ -174,7 +174,7 @@ func BuildK8SPlan(kubernetesVersion string, kubeletNodeIP string, setSELinuxPerm
 		}, plan.DependOn("configure:kubernetes-repo-key"))
 	}
 
-	// Set SELinux to permissive mode.
+	// If we need to set SELinux to permissive mode.
 	if setSELinuxPermissive {
 		b.AddResource(
 			"selinux:permissive",

--- a/pkg/plan/recipe/install_plans.go
+++ b/pkg/plan/recipe/install_plans.go
@@ -111,7 +111,7 @@ func BuildCRIPlan(criSpec *baremetalspecv1.ContainerRuntime, cfg *envcfg.EnvSpec
 	// this is a special case: if SELinux is not there on RH, CentOS Linux family
 	// installing Docker will also installing SELinux
 	// then we set SELinux mode to be permissive right after the docker installation step
-	if IsDockerOnCentOS {
+	if IsDockerOnCentOS && cfg.SetSELinuxPermissive {
 		b.AddResource(
 			"selinux:permissive",
 			&resource.Run{

--- a/pkg/plan/resource/os.go
+++ b/pkg/plan/resource/os.go
@@ -186,6 +186,17 @@ func (p *OS) HasSELinuxEnabled() (bool, error) {
 	}
 }
 
+func (p *OS) IsSELinuxPermissive() (bool, error) {
+	if _, err := p.runner.RunCommand("sestatus | grep 'Current mode' | grep permissive", nil); err == nil {
+		return true, nil
+	} else if err, ok := err.(*plan.RunError); ok && err.ExitCode == 1 {
+		// not conform with selinux permissive, may be not permissive, maybe command not found
+		return false, nil
+	} else {
+		return false, err
+	}
+}
+
 func (p *OS) IsOSInContainerVM() (bool, error) {
 	output, err := p.runner.RunCommand("cat /proc/1/environ", nil)
 	return strings.Contains(output, "container=docker"), err

--- a/pkg/plan/resource/os.go
+++ b/pkg/plan/resource/os.go
@@ -242,7 +242,7 @@ func (p *OS) IsSELinuxMode(mode string) (bool, error) {
 	if _, err := p.runner.RunCommand("sestatus | grep 'Current mode' | grep "+mode, nil); err == nil {
 		return true, nil
 	} else if err, ok := err.(*plan.RunError); ok && err.ExitCode == 1 {
-		// not conform with selinux permissive, may be not permissive, maybe command not found
+		// selinux not in the permissive mode
 		return false, nil
 	} else {
 		return false, err

--- a/pkg/utilities/envcfg/envcfg_test.go
+++ b/pkg/utilities/envcfg/envcfg_test.go
@@ -117,7 +117,7 @@ func TestGetEnvSpecificConfig(t *testing.T) {
 					cmdSELinuxEnabled:    {},
 					cmdMachineID:         {out: "01234567"},
 					cmdUUID:              {out: "01234567"},
-					cmdSELinuxPermissive: {}, //, err: &plan.RunError{ExitCode: 1}},
+					cmdSELinuxPermissive: {},
 					cmdSELinuxEnforcing:  {},
 				},
 			},

--- a/pkg/utilities/envcfg/envcfg_test.go
+++ b/pkg/utilities/envcfg/envcfg_test.go
@@ -12,12 +12,13 @@ import (
 )
 
 const (
-	cmdOsRel          = "cat /etc/os-release"
-	cmdEnv            = "cat /proc/1/environ"
-	cmdSELinuxFound   = `command -v -- "selinuxenabled" >/dev/null 2>&1`
-	cmdSELinuxEnabled = `selinuxenabled`
-	cmdMachineID      = "cat /etc/machine-id 2>/dev/null || cat /var/lib/dbus/machine-id 2>/dev/null"
-	cmdUUID           = "cat /sys/class/dmi/id/product_uuid 2>/dev/null || cat /etc/machine-id 2>/dev/null"
+	cmdOsRel             = "cat /etc/os-release"
+	cmdEnv               = "cat /proc/1/environ"
+	cmdSELinuxFound      = `command -v -- "selinuxenabled" >/dev/null 2>&1`
+	cmdSELinuxEnabled    = `selinuxenabled`
+	cmdMachineID         = "cat /etc/machine-id 2>/dev/null || cat /var/lib/dbus/machine-id 2>/dev/null"
+	cmdUUID              = "cat /sys/class/dmi/id/product_uuid 2>/dev/null || cat /etc/machine-id 2>/dev/null"
+	cmdSELinuxPermissive = "sestatus | grep 'Current mode' | grep permissive"
 
 	relUbuntu    = "ID=ubuntu\nVERSION_ID=\"18.04\""
 	relCentos    = "ID=centos\nVERSION_ID=7\n"
@@ -64,12 +65,13 @@ func TestGetEnvSpecificConfig(t *testing.T) {
 			pkgType: resource.PkgTypeDeb,
 			runner: &fakeRunner{
 				value: map[string]runnerResult{
-					cmdOsRel:          {out: relUbuntu},
-					cmdEnv:            {out: envContainer},
-					cmdSELinuxFound:   {},
-					cmdSELinuxEnabled: {},
-					cmdMachineID:      {out: "01234567"},
-					cmdUUID:           {out: "01234567"},
+					cmdOsRel:             {out: relUbuntu},
+					cmdEnv:               {out: envContainer},
+					cmdSELinuxFound:      {},
+					cmdSELinuxEnabled:    {},
+					cmdMachineID:         {out: "01234567"},
+					cmdUUID:              {out: "01234567"},
+					cmdSELinuxPermissive: {},
 				},
 			},
 
@@ -85,11 +87,12 @@ func TestGetEnvSpecificConfig(t *testing.T) {
 			pkgType: resource.PkgTypeDeb,
 			runner: &fakeRunner{
 				value: map[string]runnerResult{
-					cmdOsRel:        {out: relUbuntu},
-					cmdEnv:          {out: envContainer},
-					cmdSELinuxFound: {err: &plan.RunError{ExitCode: 1}},
-					cmdMachineID:    {out: "01234567"},
-					cmdUUID:         {out: "01234567"},
+					cmdOsRel:             {out: relUbuntu},
+					cmdEnv:               {out: envContainer},
+					cmdSELinuxFound:      {err: &plan.RunError{ExitCode: 1}},
+					cmdMachineID:         {out: "01234567"},
+					cmdUUID:              {out: "01234567"},
+					cmdSELinuxPermissive: {},
 				},
 			},
 
@@ -105,12 +108,13 @@ func TestGetEnvSpecificConfig(t *testing.T) {
 			pkgType: resource.PkgTypeRPM,
 			runner: &fakeRunner{
 				value: map[string]runnerResult{
-					cmdOsRel:          {out: relCentos},
-					cmdEnv:            {out: envContainer},
-					cmdSELinuxFound:   {},
-					cmdSELinuxEnabled: {},
-					cmdMachineID:      {out: "01234567"},
-					cmdUUID:           {out: "01234567"},
+					cmdOsRel:             {out: relCentos},
+					cmdEnv:               {out: envContainer},
+					cmdSELinuxFound:      {},
+					cmdSELinuxEnabled:    {},
+					cmdMachineID:         {out: "01234567"},
+					cmdUUID:              {out: "01234567"},
+					cmdSELinuxPermissive: {}, //, err: &plan.RunError{ExitCode: 1}},
 				},
 			},
 
@@ -126,12 +130,13 @@ func TestGetEnvSpecificConfig(t *testing.T) {
 			pkgType: resource.PkgTypeRPM,
 			runner: &fakeRunner{
 				value: map[string]runnerResult{
-					cmdOsRel:          {out: relCentos},
-					cmdEnv:            {},
-					cmdSELinuxFound:   {},
-					cmdSELinuxEnabled: {},
-					cmdMachineID:      {out: "01234567"},
-					cmdUUID:           {out: "01234567"},
+					cmdOsRel:             {out: relCentos},
+					cmdEnv:               {},
+					cmdSELinuxFound:      {},
+					cmdSELinuxEnabled:    {},
+					cmdMachineID:         {out: "01234567"},
+					cmdUUID:              {out: "01234567"},
+					cmdSELinuxPermissive: {err: &plan.RunError{ExitCode: 1}},
 				},
 			},
 
@@ -146,11 +151,12 @@ func TestGetEnvSpecificConfig(t *testing.T) {
 			pkgType: resource.PkgTypeRPM,
 			runner: &fakeRunner{
 				value: map[string]runnerResult{
-					cmdOsRel:        {out: relCentos},
-					cmdEnv:          {},
-					cmdSELinuxFound: {err: &plan.RunError{ExitCode: 1}},
-					cmdMachineID:    {out: "01234567"},
-					cmdUUID:         {out: "01234567"},
+					cmdOsRel:             {out: relCentos},
+					cmdEnv:               {},
+					cmdSELinuxFound:      {err: &plan.RunError{ExitCode: 1}},
+					cmdMachineID:         {out: "01234567"},
+					cmdUUID:              {out: "01234567"},
+					cmdSELinuxPermissive: {},
 				},
 			},
 
@@ -165,11 +171,12 @@ func TestGetEnvSpecificConfig(t *testing.T) {
 			pkgType: resource.PkgTypeDeb,
 			runner: &fakeRunner{
 				value: map[string]runnerResult{
-					cmdOsRel:        {out: relUbuntu},
-					cmdEnv:          {},
-					cmdSELinuxFound: {err: &plan.RunError{ExitCode: 1}},
-					cmdMachineID:    {out: "01234567"},
-					cmdUUID:         {out: "01234567"},
+					cmdOsRel:             {out: relUbuntu},
+					cmdEnv:               {},
+					cmdSELinuxFound:      {err: &plan.RunError{ExitCode: 1}},
+					cmdMachineID:         {out: "01234567"},
+					cmdUUID:              {out: "01234567"},
+					cmdSELinuxPermissive: {},
 				},
 			},
 
@@ -184,11 +191,12 @@ func TestGetEnvSpecificConfig(t *testing.T) {
 			pkgType: resource.PkgTypeDeb,
 			runner: &fakeRunner{
 				value: map[string]runnerResult{
-					cmdOsRel:        {out: relUbuntu},
-					cmdEnv:          {},
-					cmdSELinuxFound: {err: &plan.RunError{ExitCode: 127}},
-					cmdMachineID:    {out: "01234567"},
-					cmdUUID:         {out: "01234567"},
+					cmdOsRel:             {out: relUbuntu},
+					cmdEnv:               {},
+					cmdSELinuxFound:      {err: &plan.RunError{ExitCode: 127}},
+					cmdMachineID:         {out: "01234567"},
+					cmdUUID:              {out: "01234567"},
+					cmdSELinuxPermissive: {},
 				},
 			},
 
@@ -203,12 +211,13 @@ func TestGetEnvSpecificConfig(t *testing.T) {
 			pkgType: resource.PkgTypeDeb,
 			runner: &fakeRunner{
 				value: map[string]runnerResult{
-					cmdOsRel:          {out: relUbuntu},
-					cmdEnv:            {},
-					cmdSELinuxFound:   {},
-					cmdSELinuxEnabled: {},
-					cmdMachineID:      {out: "01234567"},
-					cmdUUID:           {out: "01234567"},
+					cmdOsRel:             {out: relUbuntu},
+					cmdEnv:               {},
+					cmdSELinuxFound:      {},
+					cmdSELinuxEnabled:    {},
+					cmdMachineID:         {out: "01234567"},
+					cmdUUID:              {out: "01234567"},
+					cmdSELinuxPermissive: {err: &plan.RunError{ExitCode: 1}},
 				},
 			},
 
@@ -223,12 +232,13 @@ func TestGetEnvSpecificConfig(t *testing.T) {
 			pkgType: resource.PkgTypeDeb,
 			runner: &fakeRunner{
 				value: map[string]runnerResult{
-					cmdOsRel:          {out: relUbuntu},
-					cmdEnv:            {},
-					cmdSELinuxFound:   {},
-					cmdSELinuxEnabled: {err: &plan.RunError{ExitCode: 1}},
-					cmdMachineID:      {out: "01234567"},
-					cmdUUID:           {out: "01234567"},
+					cmdOsRel:             {out: relUbuntu},
+					cmdEnv:               {},
+					cmdSELinuxFound:      {},
+					cmdSELinuxEnabled:    {err: &plan.RunError{ExitCode: 1}},
+					cmdMachineID:         {out: "01234567"},
+					cmdUUID:              {out: "01234567"},
+					cmdSELinuxPermissive: {err: &plan.RunError{ExitCode: 1}},
 				},
 			},
 
@@ -243,11 +253,12 @@ func TestGetEnvSpecificConfig(t *testing.T) {
 			pkgType: resource.PkgTypeRPM,
 			runner: &fakeRunner{
 				value: map[string]runnerResult{
-					cmdOsRel:        {out: relUbuntu, err: errors.New("kaboom")},
-					cmdEnv:          {},
-					cmdSELinuxFound: {},
-					cmdMachineID:    {out: "01234567"},
-					cmdUUID:         {out: "01234567"},
+					cmdOsRel:             {out: relUbuntu, err: errors.New("kaboom")},
+					cmdEnv:               {},
+					cmdSELinuxFound:      {},
+					cmdMachineID:         {out: "01234567"},
+					cmdUUID:              {out: "01234567"},
+					cmdSELinuxPermissive: {},
 				},
 			},
 			wantError: true,
@@ -257,12 +268,13 @@ func TestGetEnvSpecificConfig(t *testing.T) {
 			pkgType: resource.PkgTypeRPM,
 			runner: &fakeRunner{
 				value: map[string]runnerResult{
-					cmdOsRel:          {out: relUbuntu},
-					cmdEnv:            {err: errors.New("kaboom")},
-					cmdSELinuxFound:   {},
-					cmdSELinuxEnabled: {},
-					cmdMachineID:      {out: "01234567"},
-					cmdUUID:           {out: "01234567"},
+					cmdOsRel:             {out: relUbuntu},
+					cmdEnv:               {err: errors.New("kaboom")},
+					cmdSELinuxFound:      {},
+					cmdSELinuxEnabled:    {},
+					cmdMachineID:         {out: "01234567"},
+					cmdUUID:              {out: "01234567"},
+					cmdSELinuxPermissive: {},
 				},
 			},
 			wantError: true,
@@ -272,12 +284,13 @@ func TestGetEnvSpecificConfig(t *testing.T) {
 			pkgType: resource.PkgTypeRPM,
 			runner: &fakeRunner{
 				value: map[string]runnerResult{
-					cmdOsRel:          {out: relUbuntu},
-					cmdEnv:            {},
-					cmdSELinuxFound:   {},
-					cmdSELinuxEnabled: {err: &plan.RunError{ExitCode: 127}},
-					cmdMachineID:      {out: "01234567"},
-					cmdUUID:           {out: "01234567"},
+					cmdOsRel:             {out: relUbuntu},
+					cmdEnv:               {},
+					cmdSELinuxFound:      {},
+					cmdSELinuxEnabled:    {err: &plan.RunError{ExitCode: 127}},
+					cmdMachineID:         {out: "01234567"},
+					cmdUUID:              {out: "01234567"},
+					cmdSELinuxPermissive: {},
 				},
 			},
 			wantError: true,

--- a/pkg/utilities/envcfg/envcfg_test.go
+++ b/pkg/utilities/envcfg/envcfg_test.go
@@ -19,6 +19,7 @@ const (
 	cmdMachineID         = "cat /etc/machine-id 2>/dev/null || cat /var/lib/dbus/machine-id 2>/dev/null"
 	cmdUUID              = "cat /sys/class/dmi/id/product_uuid 2>/dev/null || cat /etc/machine-id 2>/dev/null"
 	cmdSELinuxPermissive = "sestatus | grep 'Current mode' | grep permissive"
+	cmdSELinuxEnforcing  = "sestatus | grep 'Current mode' | grep enforcing"
 
 	relUbuntu    = "ID=ubuntu\nVERSION_ID=\"18.04\""
 	relCentos    = "ID=centos\nVERSION_ID=7\n"
@@ -72,6 +73,7 @@ func TestGetEnvSpecificConfig(t *testing.T) {
 					cmdMachineID:         {out: "01234567"},
 					cmdUUID:              {out: "01234567"},
 					cmdSELinuxPermissive: {},
+					cmdSELinuxEnforcing:  {},
 				},
 			},
 
@@ -92,7 +94,8 @@ func TestGetEnvSpecificConfig(t *testing.T) {
 					cmdSELinuxFound:      {err: &plan.RunError{ExitCode: 1}},
 					cmdMachineID:         {out: "01234567"},
 					cmdUUID:              {out: "01234567"},
-					cmdSELinuxPermissive: {},
+					cmdSELinuxPermissive: {err: &plan.RunError{ExitCode: 1}},
+					cmdSELinuxEnforcing:  {err: &plan.RunError{ExitCode: 1}},
 				},
 			},
 
@@ -115,6 +118,7 @@ func TestGetEnvSpecificConfig(t *testing.T) {
 					cmdMachineID:         {out: "01234567"},
 					cmdUUID:              {out: "01234567"},
 					cmdSELinuxPermissive: {}, //, err: &plan.RunError{ExitCode: 1}},
+					cmdSELinuxEnforcing:  {},
 				},
 			},
 
@@ -137,6 +141,7 @@ func TestGetEnvSpecificConfig(t *testing.T) {
 					cmdMachineID:         {out: "01234567"},
 					cmdUUID:              {out: "01234567"},
 					cmdSELinuxPermissive: {err: &plan.RunError{ExitCode: 1}},
+					cmdSELinuxEnforcing:  {},
 				},
 			},
 
@@ -156,7 +161,8 @@ func TestGetEnvSpecificConfig(t *testing.T) {
 					cmdSELinuxFound:      {err: &plan.RunError{ExitCode: 1}},
 					cmdMachineID:         {out: "01234567"},
 					cmdUUID:              {out: "01234567"},
-					cmdSELinuxPermissive: {},
+					cmdSELinuxPermissive: {err: &plan.RunError{ExitCode: 1}},
+					cmdSELinuxEnforcing:  {err: &plan.RunError{ExitCode: 1}},
 				},
 			},
 
@@ -177,6 +183,7 @@ func TestGetEnvSpecificConfig(t *testing.T) {
 					cmdMachineID:         {out: "01234567"},
 					cmdUUID:              {out: "01234567"},
 					cmdSELinuxPermissive: {},
+					cmdSELinuxEnforcing:  {},
 				},
 			},
 
@@ -197,6 +204,7 @@ func TestGetEnvSpecificConfig(t *testing.T) {
 					cmdMachineID:         {out: "01234567"},
 					cmdUUID:              {out: "01234567"},
 					cmdSELinuxPermissive: {},
+					cmdSELinuxEnforcing:  {},
 				},
 			},
 
@@ -218,6 +226,7 @@ func TestGetEnvSpecificConfig(t *testing.T) {
 					cmdMachineID:         {out: "01234567"},
 					cmdUUID:              {out: "01234567"},
 					cmdSELinuxPermissive: {err: &plan.RunError{ExitCode: 1}},
+					cmdSELinuxEnforcing:  {},
 				},
 			},
 
@@ -239,6 +248,7 @@ func TestGetEnvSpecificConfig(t *testing.T) {
 					cmdMachineID:         {out: "01234567"},
 					cmdUUID:              {out: "01234567"},
 					cmdSELinuxPermissive: {err: &plan.RunError{ExitCode: 1}},
+					cmdSELinuxEnforcing:  {err: &plan.RunError{ExitCode: 1}},
 				},
 			},
 
@@ -259,6 +269,7 @@ func TestGetEnvSpecificConfig(t *testing.T) {
 					cmdMachineID:         {out: "01234567"},
 					cmdUUID:              {out: "01234567"},
 					cmdSELinuxPermissive: {},
+					cmdSELinuxEnforcing:  {},
 				},
 			},
 			wantError: true,
@@ -275,6 +286,7 @@ func TestGetEnvSpecificConfig(t *testing.T) {
 					cmdMachineID:         {out: "01234567"},
 					cmdUUID:              {out: "01234567"},
 					cmdSELinuxPermissive: {},
+					cmdSELinuxEnforcing:  {},
 				},
 			},
 			wantError: true,
@@ -291,6 +303,7 @@ func TestGetEnvSpecificConfig(t *testing.T) {
 					cmdMachineID:         {out: "01234567"},
 					cmdUUID:              {out: "01234567"},
 					cmdSELinuxPermissive: {},
+					cmdSELinuxEnforcing:  {},
 				},
 			},
 			wantError: true,

--- a/pkg/utilities/envcfg/environment_config.go
+++ b/pkg/utilities/envcfg/environment_config.go
@@ -42,6 +42,10 @@ func GetEnvSpecificConfig(pkgType resource.PkgType, namespace string, cloudProvi
 	if err != nil {
 		return nil, errors.Wrap(err, "HasSELinuxEnabled")
 	}
+	isSELinuxPermissive, err := osres.IsSELinuxPermissive()
+	if err != nil {
+		return nil, errors.Wrap(err, "IsSELinuxPermissive")
+	}
 
 	inContainerVM, err := osres.IsOSInContainerVM()
 	if err != nil {
@@ -65,7 +69,7 @@ func GetEnvSpecificConfig(pkgType resource.PkgType, namespace string, cloudProvi
 	config := &EnvSpecificConfig{
 		ConntrackMax:          0,
 		UseIPTables:           !inContainerVM,
-		SetSELinuxPermissive:  !inContainerVM && seLinuxEnabled,
+		SetSELinuxPermissive:  !inContainerVM && seLinuxEnabled && !isSELinuxPermissive, // if it's already permissive, do nothing
 		LockYUMPkgs:           pkgType == resource.PkgTypeRPM,
 		DisableSwap:           !inContainerVM,
 		IgnorePreflightErrors: ignorePreflightErrors,


### PR DESCRIPTION
This PR improves the detection of SELinux permissive mode to prevent node re-provision.
It requires #128 to be merged.

Fixes #135 
