### PR TITLE
[WKP-46] Adds eksctl functions to write and merge kubeconfig files

### DIFF
--- a/cmd/wksctl/kubeconfig/kubeconfig.go
+++ b/cmd/wksctl/kubeconfig/kubeconfig.go
@@ -2,7 +2,6 @@ package kubeconfig
 
 import (
 	"fmt"
-	"io/ioutil"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -12,6 +11,7 @@ import (
 	"github.com/weaveworks/wksctl/pkg/specs"
 	"github.com/weaveworks/wksctl/pkg/utilities/manifest"
 	"github.com/weaveworks/wksctl/pkg/utilities/path"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 // A new version of the kubeconfig command that retrieves the config from
@@ -19,9 +19,10 @@ import (
 
 // Cmd represents the kubeconfig command
 var Cmd = &cobra.Command{
-	Use:   "kubeconfig",
-	Short: "Generate a kubeconfig file for the cluster",
-	RunE:  kubeconfigRun,
+	Use:          "kubeconfig",
+	Short:        "Generate a kubeconfig file for the cluster",
+	RunE:         kubeconfigRun,
+	SilenceUsage: true,
 }
 
 var kubeconfigOptions struct {
@@ -34,6 +35,7 @@ var kubeconfigOptions struct {
 	artifactDirectory    string
 	namespace            string
 	sshKeyPath           string
+	useContext           bool
 	skipTLSVerify        bool
 	useLocalhost         bool
 	usePublicAddress     bool
@@ -56,6 +58,9 @@ func init() {
 		&kubeconfigOptions.artifactDirectory, "artifact-directory", "", "Write output files in the specified directory")
 	Cmd.Flags().StringVar(
 		&kubeconfigOptions.namespace, "namespace", manifest.DefaultNamespace, "namespace portion of kubeconfig path")
+	Cmd.Flags().BoolVar(
+		&kubeconfigOptions.useContext, "use-context", true,
+		"Set current context to the newly created one")
 	Cmd.Flags().BoolVar(
 		&kubeconfigOptions.skipTLSVerify, "insecure-skip-tls-verify", false,
 		"Enables kubectl to communicate with the API w/o verifying the certificate")
@@ -93,29 +98,48 @@ func kubeconfigRun(cmd *cobra.Command, args []string) error {
 }
 
 func writeKubeconfig(cpath, mpath string) error {
-	wksHome, err := path.CreateDirectory(
-		path.WKSHome(kubeconfigOptions.artifactDirectory))
-	if err != nil {
-		return errors.Wrapf(err, "failed to create WKS home directory")
-	}
+	var wksHome string
+	var err error
+	var configPath string
+
 	sp := specs.NewFromPaths(cpath, mpath)
+
+	if kubeconfigOptions.artifactDirectory != "" {
+		wksHome, err = path.CreateDirectory(
+			path.WKSHome(kubeconfigOptions.artifactDirectory))
+		if err != nil {
+			return errors.Wrapf(err, "failed to create WKS home directory")
+		}
+
+		_, err = path.CreateDirectory(filepath.Dir(configPath))
+		if err != nil {
+			return errors.Wrapf(err, "failed to create configuration directory")
+		}
+		configPath = path.Kubeconfig(wksHome, kubeconfigOptions.namespace, sp.GetClusterName())
+	} else {
+		configPath = clientcmd.RecommendedHomeFile
+	}
 
 	configStr, err := config.GetRemoteKubeconfig(sp, kubeconfigOptions.sshKeyPath, kubeconfigOptions.verbose, kubeconfigOptions.skipTLSVerify)
 	if err != nil {
-		return errors.Wrapf(err, "GetRemoteKubeconfig")
+		return errors.Wrapf(err, "failed to get remote kubeconfig")
 	}
 
-	configPath := path.Kubeconfig(wksHome, kubeconfigOptions.namespace, sp.GetClusterName())
-
-	_, err = path.CreateDirectory(filepath.Dir(configPath))
+	remoteConfig, err := clientcmd.Load([]byte(configStr))
 	if err != nil {
-		return errors.Wrapf(err, "failed to create configuration directory")
+		return errors.Wrapf(err, "failed to load kubeconfig")
 	}
+	config.RenameConfig(sp, remoteConfig)
 
-	err = ioutil.WriteFile(configPath, []byte(configStr), 0644)
+	configPath, err = config.Write(configPath, *remoteConfig, kubeconfigOptions.useContext)
 	if err != nil {
 		return errors.Wrapf(err, "failed to write Kubernetes configuration locally")
 	}
-	fmt.Printf("To use kubectl with the %s cluster, enter:\n$ export KUBECONFIG=%s\n", sp.GetClusterName(), configPath)
+	if kubeconfigOptions.artifactDirectory != "" {
+		fmt.Printf("To use kubectl with the %s cluster, enter:\n$ export KUBECONFIG=%s\n", sp.GetClusterName(), configPath)
+	} else {
+		fmt.Printf("The kubeconfig file at %q has been updated\n", configPath)
+	}
+
 	return nil
 }

--- a/cmd/wksctl/main.go
+++ b/cmd/wksctl/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
 	log "github.com/sirupsen/logrus"
@@ -66,7 +65,6 @@ func main() {
 	}
 
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Println(err)
 		os.Exit(1)
 	}
 

--- a/docs/wks-and-footloose.md
+++ b/docs/wks-and-footloose.md
@@ -74,9 +74,7 @@ These commands assume you are in the `examples/footloose` directory.
 
    ```console
    $ wksctl kubeconfig --cluster=cluster.yaml
-   To use kubectl with the example cluster, enter:
-   export KUBECONFIG=$HOME/.wks/weavek8sops/example/kubeconfig
-   $ export KUBECONFIG=/home/lucas/.wks/weavek8sops/example/kubeconfig
+   The kubeconfig file at "/home/dinos/.kube/config" has been updated
    $ kubectl get nodes
    NAME               STATUS   ROLES    AGE   VERSION
    b4fdde36eb122804   Ready    master   77s   v1.14.1

--- a/pkg/utilities/path/path.go
+++ b/pkg/utilities/path/path.go
@@ -7,6 +7,8 @@ import (
 	"os/user"
 	"path/filepath"
 	"strings"
+
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 // UserHomeDirectory returns the user directory.
@@ -44,14 +46,7 @@ func WKSHome(artifactDirectory string) string {
 	if artifactDirectory != "" {
 		return expandHome(artifactDirectory)
 	}
-
-	userHome, err := UserHomeDirectory()
-	if err == nil {
-		return filepath.Join(userHome, ".wks")
-	}
-
-	wd, _ := os.Getwd()
-	return wd
+	return clientcmd.RecommendedHomeFile
 }
 
 // WKSResourcePath joins the provided (optional) artifact directory and the

--- a/test/integration/test/apply_test.go
+++ b/test/integration/test/apply_test.go
@@ -7,11 +7,11 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
-	"os/user"
-	"path"
 	"path/filepath"
 	"testing"
 	"time"
+
+	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/weaveworks/wksctl/pkg/cluster/machine"
 	"github.com/weaveworks/wksctl/pkg/kubernetes"
@@ -21,12 +21,11 @@ import (
 	baremetalspecv1 "github.com/weaveworks/wksctl/pkg/baremetalproviderspec/v1alpha1"
 	spawn "github.com/weaveworks/wksctl/test/integration/spawn"
 
+	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
-
-	"github.com/stretchr/testify/assert"
 )
 
 // Runs a basic set of tests for apply.
@@ -240,13 +239,10 @@ func getClusterNamespaceAndName(t *testing.T) (string, string) {
 // The installer names the kubeconfig file from the cluster namespace and name
 // ~/.wks
 func wksKubeconfig(t *testing.T, l *clusterv1.MachineList) string {
-	currentUser, err := user.Current()
-	assert.NoError(t, err)
 	master := machine.FirstMasterInArray(l.Items)
 	assert.NotNil(t, master)
-	namespace, name := getClusterNamespaceAndName(t)
-	kubeconfig := path.Join(currentUser.HomeDir, ".wks", namespace, name, "kubeconfig")
-	_, err = os.Stat(kubeconfig)
+	kubeconfig := clientcmd.RecommendedHomeFile
+	_, err := os.Stat(kubeconfig)
 	assert.NoError(t, err)
 
 	return kubeconfig


### PR DESCRIPTION
  * Adds eksctl functions to write and merge kubeconfig files

   * Adds `--use-context` flag, to toggle switching to the new context after the creation of a cluster.
   
   * Switches context to newly created cluster by default, except if
      if `--use-context=false` is passed.
 
   * If `--artifact-directory` is not passed, and ~/.kube/config file
      exists, the context is merged in the existing file. If ~/.kube/config
      doesn't exist, it creates it.
    
   * Sets `SilenceUsage` to true in kubeconfig root command, to avoid showing
      the usage message in the case of error.
      Relevant issue: https://github.com/spf13/cobra/issues/340
    
   * Removes printing of error in `Execute()` of kubeconfig command
      to avoid printing twice an error message.
      Relevant issue: https://github.com/spf13/cobra/issues/304


Signed-off-by: Dinos Kousidis <dinos@weave.works>