### PR TITLE
[WKP-348] Updates sealed secret controller manifest to v0.11.0

### DIFF
--- a/pkg/apis/wksprovider/controller/manifests/yaml/05_sealed_secret_controller.yaml
+++ b/pkg/apis/wksprovider/controller/manifests/yaml/05_sealed_secret_controller.yaml
@@ -1,18 +1,60 @@
 ---
 apiVersion: v1
-kind: ServiceAccount
+kind: Service
 metadata:
-  name: sealed-secrets-controller
-  namespace: kube-system
----
-apiVersion: apps/v1beta1
-kind: Deployment
-metadata:
+  annotations: {}
+  labels:
+    name: sealed-secrets-controller
   name: sealed-secrets-controller
   namespace: kube-system
 spec:
+  ports:
+  - port: 8080
+    targetPort: 8080
+  selector:
+    name: sealed-secrets-controller
+  type: ClusterIP
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  annotations: {}
+  labels:
+    name: sealed-secrets-service-proxier
+  name: sealed-secrets-service-proxier
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: sealed-secrets-service-proxier
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:authenticated
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations: {}
+  labels:
+    name: sealed-secrets-controller
+  name: sealed-secrets-controller
+  namespace: kube-system
+spec:
+  minReadySeconds: 30
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      name: sealed-secrets-controller
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
+      annotations: {}
       labels:
         name: sealed-secrets-controller
     spec:
@@ -25,13 +67,16 @@ spec:
         key: node-role.kubernetes.io/master
         operator: Exists
       containers:
-      - command:
+      - args: []
+        command:
         - controller
-        image: quay.io/bitnami/sealed-secrets-controller:v0.7.0
+        env: []
+        image: quay.io/bitnami/sealed-secrets-controller:v0.11.0
+        imagePullPolicy: Always
         livenessProbe:
           httpGet:
             path: /healthz
-            port: 8080
+            port: http
         name: sealed-secrets-controller
         ports:
         - containerPort: 8080
@@ -39,27 +84,46 @@ spec:
         readinessProbe:
           httpGet:
             path: /healthz
-            port: 8080
+            port: http
         securityContext:
           readOnlyRootFilesystem: true
           runAsNonRoot: true
           runAsUser: 1001
+        stdin: false
+        tty: false
+        volumeMounts:
+        - mountPath: /tmp
+          name: tmp
+      imagePullSecrets: []
+      initContainers: []
+      securityContext:
+        fsGroup: 65534
       serviceAccountName: sealed-secrets-controller
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - emptyDir: {}
+        name: tmp
 ---
-apiVersion: v1
-kind: Service
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
 metadata:
-  name: sealed-secrets-controller
-  namespace: kube-system
+  name: sealedsecrets.bitnami.com
 spec:
-  ports:
-  - port: 8080
-  selector:
-    name: sealed-secrets-controller
+  group: bitnami.com
+  names:
+    kind: SealedSecret
+    listKind: SealedSecretList
+    plural: sealedsecrets
+    singular: sealedsecret
+  scope: Namespaced
+  version: v1alpha1
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
+  annotations: {}
+  labels:
+    name: sealed-secrets-controller
   name: sealed-secrets-controller
   namespace: kube-system
 roleRef:
@@ -67,49 +131,49 @@ roleRef:
   kind: Role
   name: sealed-secrets-key-admin
 subjects:
-- apiGroup: ""
-  kind: ServiceAccount
+- kind: ServiceAccount
   name: sealed-secrets-controller
   namespace: kube-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:
+  annotations: {}
+  labels:
+    name: sealed-secrets-key-admin
   name: sealed-secrets-key-admin
   namespace: kube-system
 rules:
-- apiGroups:
-  - ""
-  resourceNames:
-  - sealed-secrets-key
-  resources:
-  - secrets
-  verbs:
-  - get
 - apiGroups:
   - ""
   resources:
   - secrets
   verbs:
   - create
+  - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
+  annotations: {}
+  labels:
+    name: sealed-secrets-controller
   name: sealed-secrets-controller
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: secrets-unsealer
 subjects:
-- apiGroup: ""
-  kind: ServiceAccount
+- kind: ServiceAccount
   name: sealed-secrets-controller
   namespace: kube-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
+  annotations: {}
+  labels:
+    name: secrets-unsealer
   name: secrets-unsealer
 rules:
 - apiGroups:
@@ -120,11 +184,49 @@ rules:
   - get
   - list
   - watch
+  - update
 - apiGroups:
   - ""
   resources:
   - secrets
   verbs:
+  - get
   - create
   - update
   - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations: {}
+  labels:
+    name: sealed-secrets-controller
+  name: sealed-secrets-controller
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  annotations: {}
+  labels:
+    name: sealed-secrets-service-proxier
+  name: sealed-secrets-service-proxier
+  namespace: kube-system
+rules:
+- apiGroups:
+  - ""
+  resourceNames:
+  - 'http:sealed-secrets-controller:'
+  - sealed-secrets-controller
+  resources:
+  - services/proxy
+  verbs:
+  - create
+  - get

--- a/pkg/apis/wksprovider/machine/os/os.go
+++ b/pkg/apis/wksprovider/machine/os/os.go
@@ -52,7 +52,7 @@ const (
 	PemDestDir                = "/etc/pki/weaveworks/wksctl/pem"
 	authCmapName              = "authn-authz"
 	masterConfigKey           = "master-config"
-	sealedSecretVersion       = "v0.7.0"
+	sealedSecretVersion       = "v0.11.0"
 	sealedSecretKeySecretName = "sealed-secrets-key"
 )
 

--- a/pkg/plan/recipe/install_plans.go
+++ b/pkg/plan/recipe/install_plans.go
@@ -3,6 +3,8 @@ package recipe
 import (
 	"fmt"
 
+	"io/ioutil"
+
 	log "github.com/sirupsen/logrus"
 	"github.com/weaveworks/wksctl/pkg/apis/wksprovider/controller/manifests"
 	baremetalspecv1 "github.com/weaveworks/wksctl/pkg/baremetalproviderspec/v1alpha1"
@@ -10,11 +12,6 @@ import (
 	"github.com/weaveworks/wksctl/pkg/plan/resource"
 	"github.com/weaveworks/wksctl/pkg/utilities/envcfg"
 	"github.com/weaveworks/wksctl/pkg/utilities/object"
-	"io/ioutil"
-)
-
-const (
-	sealedSecretCRDURL = "https://github.com/bitnami-labs/sealed-secrets/releases/download/%s/sealedsecret-crd.yaml"
 )
 
 // BuildBasePlan creates a plan for installing the base building blocks for the node
@@ -284,10 +281,6 @@ func BuildSealedSecretPlan(sealedSecretVersion, ns string, manifest []byte) plan
 	b.AddResource("install:sealed-secrets-controller",
 		&resource.KubectlApply{Manifest: manifestbytes, Filename: object.String("SealedSecretController.yaml")},
 		plan.DependOn("install:sealed-secrets-key"))
-	b.AddResource("install:sealed-secret-crd",
-		&resource.KubectlApply{ManifestURL: object.String(fmt.Sprintf(sealedSecretCRDURL, sealedSecretVersion)),
-			WaitCondition: "condition=Established"},
-		plan.DependOn("install:sealed-secrets-controller"))
 	p, err := b.Plan()
 	if err != nil {
 		log.Fatalf("%v", err)


### PR DESCRIPTION
* Removes URL to sealed secrets CRD as it is included in the controller manifests in v0.11.0.

Some other differences between the versions:
- There is a new Role + RoleBinding for `sealed-secrets-service-proxier`
- The deployment manifest has a `RollingUpdate` strategy node, a securityContext fsGroup: 65534, the toleration to run in master nodes is added back, and an emptyDir volume at `tmp`.

Signed-off-by: Dinos Kousidis <dinos@weave.works>