### PR TITLE
integration tests - preemptible, no restarts, self-destruct in 48h

### DIFF
--- a/test/integration/bin/internal/provisioning/gcp/main.tf
+++ b/test/integration/bin/internal/provisioning/gcp/main.tf
@@ -44,6 +44,24 @@ resource "google_compute_instance" "tf_test_vm" {
     ssh-keys = "${var.gcp_username}:${file("${var.gcp_public_key_path}")}"
   }
 
+  # self destruct after 48h hours to cut down costs
+  # this is a fallback in case preemptible is disabled or doesn't occur
+  # reference: https://cloud.google.com/community/tutorials/create-a-self-deleting-virtual-machine
+  metadata_startup_script = <<-EOT
+  #!/bin/sh
+  sleep 48h
+  export NAME=$(curl -X GET http://metadata.google.internal/computeMetadata/v1/instance/name -H 'Metadata-Flavor: Google')
+  export ZONE=$(curl -X GET http://metadata.google.internal/computeMetadata/v1/instance/zone -H 'Metadata-Flavor: Google')
+  gcloud --quiet compute instances delete $NAME --zone=$ZONE
+  EOT
+
+  # make the VM preemptible to cut down costs
+  # and prevent VM from being restarted after preemption
+  scheduling {
+    preemptible = true
+    automatic_restart = false
+  }
+
   # Wait for machine to be SSH-able:
   provisioner "remote-exec" {
     inline = ["exit"]


### PR DESCRIPTION
* Enable preemptible VMs to cut down costs
* Disable VM auto restart in case of a shutdown
* Automatically delete VM in case preemptible is disabled or doesn't occur

Proof it works is in the integration test and the screenshot below

<img width="945" alt="Screen Shot 2020-03-30 at 9 52 16 PM" src="https://user-images.githubusercontent.com/1087987/77978731-cdd0d200-72d0-11ea-9fb3-7a22a766dadd.png">

Read more about [preemptible VMs](https://cloud.google.com/preemptible-vms)