### PR TITLE
Support 1.17.x

### DIFF
--- a/examples/footloose/centos7/docker/multimaster.yaml
+++ b/examples/footloose/centos7/docker/multimaster.yaml
@@ -4,7 +4,7 @@ cluster:
 machines:
 - count: 4
   spec:
-    image: quay.io/footloose/centos7:0.3.0
+    image: quay.io/footloose/centos7:0.6.0
     name: node%d
     portMappings:
     - containerPort: 22

--- a/pkg/kubernetes/version.go
+++ b/pkg/kubernetes/version.go
@@ -4,4 +4,4 @@ package kubernetes
 const DefaultVersion = "1.14.1"
 
 // DefaultVersionsRange is the default Kubernetes versions' range used by WKS to validate Kubernetes versions.
-const DefaultVersionsRange = ">=1.14.1 <=1.16.8"
+const DefaultVersionsRange = ">=1.14.1 <=1.17.5"

--- a/pkg/plan/resource/kubeadm_init.go
+++ b/pkg/plan/resource/kubeadm_init.go
@@ -293,7 +293,7 @@ func buildKubeadmInitPlan(path string, ignorePreflightErrors string, useIPTables
 		// N.B.: --experimental-upload-certs encrypts & uploads
 		// certificates of the primary control plane in the kubeadm-certs
 		// Secret, and prints the value for --certificate-key to STDOUT.
-		&Run{Script: object.String(fmt.Sprintf("kubeadm init --config=%s --ignore-preflight-errors=%s %s", &path, &ignorePreflightErrors, &uploadCertsFlag)),
+		&Run{Script: plan.ParamString("kubeadm init --config=%s --ignore-preflight-errors=%s %s", &path, &ignorePreflightErrors, &uploadCertsFlag),
 			UndoResource: buildKubeadmRunInitUndoPlan(),
 			Output:       output,
 		},


### PR DESCRIPTION
This PR adding support for bootstrap K8s 1.17.
It contains a new step in the plan to check if we're on 1.17 and convert the old kubeadm config file to the new version.

From the 1.17 release note:

> kubeadm.k8s.io/v1beta1 has been deprecated, you should update your config to use newer non-deprecated API versions. (kubernetes/kubernetes#83276, @Klaven)

This PR also change the upper bound of supported version to 1.17.5.