### PR TITLE
Update build image to Go 1.13.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,8 +103,8 @@ jobs:
     machine:
       docker_layer_caching: true
     environment:
-      GOURL: https://dl.google.com/go/go1.12.7.linux-amd64.tar.gz
-      GOCHECKSUM: 66d83bfb5a9ede000e33c6579a91a29e6b101829ad41fffb5c5bb6c900e109d9
+      GOURL: https://dl.google.com/go/go1.13.5.linux-amd64.tar.gz
+      GOCHECKSUM: 512103d7ad296467814a6e3f635631bd35574cab3369a97a323c9a585ccaa569
       GOROOT: /home/circleci/goroot
       GOPATH: /home/circleci/go
       SRCDIR: /home/circleci/src/github.com/weaveworks/wksctl
@@ -127,8 +127,8 @@ jobs:
     machine:
       docker_layer_caching: true
     environment:
-      GOURL: https://dl.google.com/go/go1.12.7.linux-amd64.tar.gz
-      GOCHECKSUM: 66d83bfb5a9ede000e33c6579a91a29e6b101829ad41fffb5c5bb6c900e109d9
+      GOURL: https://dl.google.com/go/go1.13.5.linux-amd64.tar.gz
+      GOCHECKSUM: 512103d7ad296467814a6e3f635631bd35574cab3369a97a323c9a585ccaa569
       GOROOT: /home/circleci/goroot
       GOPATH: /home/circleci/go
       SRCDIR: /home/circleci/src/github.com/weaveworks/wksctl

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,8 @@ defaults: &defaults
       environment:
         GOPATH: /go/
         SRCDIR: /src/github.com/weaveworks/wksctl
+        KUBECTL_URL: https://dl.k8s.io/v1.10.5/kubernetes-client-linux-amd64.tar.gz
+        KUBECTL_CHECKSUM: da9d557989a0b9671a610f21642052febb8f70c3cf144c98a8a4f7ecab6bafe2
   working_directory: /src/github.com/weaveworks/wksctl
 
 workflows:
@@ -69,14 +71,7 @@ jobs:
               make push
             fi
   unit-tests:
-    docker:
-      - image: docker.io/weaveworks/wksctl-build:switch-away-from-quay-53c3c712-WIP
-        environment:
-          GOPATH: /go
-          SRCDIR: /src/github.com/weaveworks/wksctl
-          KUBECTL_URL: https://dl.k8s.io/v1.10.5/kubernetes-client-linux-amd64.tar.gz
-          KUBECTL_CHECKSUM: da9d557989a0b9671a610f21642052febb8f70c3cf144c98a8a4f7ecab6bafe2
-    working_directory: /src/github.com/weaveworks/wksctl
+    <<: *defaults
     steps:
       - checkout
       - run:
@@ -188,18 +183,8 @@ jobs:
   # https://console.cloud.google.com/compute/instances?project=wks-tests
   #
   integration-tests-gcp-centos:
-    docker:
-      - image: docker.io/weaveworks/wksctl-build:switch-away-from-quay-53c3c712-WIP
-        environment:
-          GOPATH: /go/
-          SRCDIR: /src/github.com/weaveworks/wksctl
-          KUBECTL_URL: https://dl.k8s.io/v1.10.5/kubernetes-client-linux-amd64.tar.gz
-          KUBECTL_CHECKSUM: da9d557989a0b9671a610f21642052febb8f70c3cf144c98a8a4f7ecab6bafe2
-          CREATE_IMAGE: 1
-          USE_IMAGE: 1
-          IMAGE_NAME: centos-cloud/centos-7
-          WKP_DEBUG: true
-    working_directory: /src/github.com/weaveworks/wksctl
+
+    <<: *defaults
     steps:
       - checkout
       - setup_remote_docker
@@ -218,23 +203,15 @@ jobs:
           name: Centos integration tests
           command: |
             if [ -n "$SECRET_KEY" ]; then
+              export IMAGE_NAME=centos-cloud/centos-7
+              export WKP_DEBUG=true
               $SRCDIR/test/integration/bin/up.sh
               $SRCDIR/test/integration/bin/test.sh
               $SRCDIR/test/integration/bin/down.sh
             fi
       - run: "true"
   integration-tests-gcp-ubuntu:
-    docker:
-      - image: docker.io/weaveworks/wksctl-build:switch-away-from-quay-53c3c712-WIP
-        environment:
-          GOPATH: /go/
-          SRCDIR: /src/github.com/weaveworks/wksctl
-          KUBECTL_URL: https://dl.k8s.io/v1.10.5/kubernetes-client-linux-amd64.tar.gz
-          KUBECTL_CHECKSUM: da9d557989a0b9671a610f21642052febb8f70c3cf144c98a8a4f7ecab6bafe2
-          CREATE_IMAGE: 0
-          USE_IMAGE: 0
-          IMAGE_NAME: ubuntu-os-cloud/ubuntu-1804-bionic-v20190530
-    working_directory: /src/github.com/weaveworks/wksctl
+    <<: *defaults
     steps:
       - checkout
       - setup_remote_docker
@@ -254,24 +231,16 @@ jobs:
           name: Ubuntu integration tests
           command: |
             if [ -n "$SECRET_KEY" ]; then
+              export CREATE_IMAGE=0
+              export USE_IMAGE=0
+              export IMAGE_NAME=ubuntu-os-cloud/ubuntu-1804-bionic-v20190530
               $SRCDIR/test/integration/bin/up.sh
               $SRCDIR/test/integration/bin/test.sh
               $SRCDIR/test/integration/bin/down.sh
             fi
       - run: "true"
   integration-tests-gcp-rhel:
-    docker:
-      - image: docker.io/weaveworks/wksctl-build:switch-away-from-quay-53c3c712-WIP
-        environment:
-          GOPATH: /go/
-          SRCDIR: /src/github.com/weaveworks/wksctl
-          KUBECTL_URL: https://dl.k8s.io/v1.10.5/kubernetes-client-linux-amd64.tar.gz
-          KUBECTL_CHECKSUM: da9d557989a0b9671a610f21642052febb8f70c3cf144c98a8a4f7ecab6bafe2
-          CREATE_IMAGE: 1
-          USE_IMAGE: 1
-          IMAGE_NAME: rhel-cloud/rhel-7
-          WKP_DEBUG: false
-    working_directory: /src/github.com/weaveworks/wksctl
+    <<: *defaults
     steps:
       - checkout
       - setup_remote_docker
@@ -291,6 +260,8 @@ jobs:
           name: rhel integration tests
           command: |
             if [ -n "$SECRET_KEY" ]; then
+              export IMAGE_NAME=rhel-cloud/rhel-7
+              export WKP_DEBUG=false
               $SRCDIR/test/integration/bin/up.sh
               $SRCDIR/test/integration/bin/test.sh
               $SRCDIR/test/integration/bin/down.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 # https://circleci.com/blog/circleci-hacks-reuse-yaml-in-your-circleci-config-with-yaml/
 defaults: &defaults
   docker:
-    - image: docker.io/weaveworks/wksctl-build:switch-away-from-quay-53c3c712-WIP
+    - image: quay.io/wks/build:update-build-image-f86284c8
       environment:
         GOPATH: /go/
         SRCDIR: /src/github.com/weaveworks/wksctl

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,8 +127,6 @@ jobs:
       GOROOT: /home/circleci/goroot
       GOPATH: /home/circleci/go
       SRCDIR: /home/circleci/src/github.com/weaveworks/wksctl
-      HUGO_URL: https://github.com/gohugoio/hugo/releases/download/v0.55.6/hugo_0.55.6_Linux-64bit.tar.gz
-      HUGO_CHECKSUM: 39d3119cdb9ba5d6f1f1b43693e707937ce851791a2ea8d28003f49927c428f4
       FOOTLOOSE_URL: https://github.com/weaveworks/footloose/releases/download/0.5.0/footloose-0.5.0-linux-x86_64
       FOOTLOOSE_CHECKSUM: 0e4e49e81940c5876eafa26607154acd788d9979e9f4a4215f17532a3ea5429a
       KUBECTL_URL: https://dl.k8s.io/v1.10.5/kubernetes-client-linux-amd64.tar.gz
@@ -141,14 +139,6 @@ jobs:
           command: |
             (cd ~ && curl -L $GOURL -o go.tar.gz && echo "$GOCHECKSUM go.tar.gz" | sha256sum -c)
             mkdir -p $GOROOT && tar xf ~/go.tar.gz -C $GOROOT --strip-components 1
-      - run:
-          name: Install hugo
-          command: |
-            curl -L $HUGO_URL -o hugo.tar.gz
-            echo "$HUGO_CHECKSUM hugo.tar.gz" | sha256sum -c
-            tar xzf hugo.tar.gz hugo
-            chmod +x hugo
-            sudo mv hugo /usr/local/bin
       - run:
           name: Install footloose
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 # https://circleci.com/blog/circleci-hacks-reuse-yaml-in-your-circleci-config-with-yaml/
 defaults: &defaults
   docker:
-    - image: quay.io/wks/build:update-build-image-f86284c8
+    - image: docker.io/weaveworks/wksctl-build:update-build-image-cb52a6ea
       environment:
         GOPATH: /go/
         SRCDIR: /src/github.com/weaveworks/wksctl

--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ push:
 # We select which directory we want to descend into to not execute integration
 # tests here.
 unit-tests: generated
-	go test -v ./cmd/... ./pkg/...
+	go test -p 1 -v ./cmd/... ./pkg/...
 
 # Tests running in containers
 mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,9 +1,9 @@
-FROM weaveworks/build-golang:1.12.1-stretch
+FROM weaveworks/build-golang:1.13.5-stretch
 
 RUN apt-get update && \
     apt-get install -y \
       sudo \
-      python-pip python-dev libffi-dev libssl-dev awscli \
+      libffi-dev awscli \
       && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -35,13 +35,12 @@ RUN curl -fsSLo docker.tgz https://download.docker.com/linux/static/stable/x86_6
     tar xzvf docker.tgz --strip 1 -C /usr/local/bin docker/docker && \
     rm docker.tgz;
 
-# Install gometalinter
-ENV GOMETALINTER_VERSION 2.0.11
-ENV ARCH amd64
-RUN curl -fsSLo gometalinter.tar.gz --compressed "https://github.com/alecthomas/gometalinter/releases/download/v$GOMETALINTER_VERSION/gometalinter-$GOMETALINTER_VERSION-linux-$ARCH.tar.gz" && \
-    echo "97d8bd0a4d024740964c7fc2ae41276cf5f839ccf0749528ca900942f656d201 gometalinter.tar.gz" | sha256sum -c && \
-    tar xf gometalinter.tar.gz -C /usr/bin --strip-components=1 --no-same-owner && \
-    rm gometalinter.tar.gz
+# Install golangci-lint
+ENV GOLANGCILINTVERSION=1.17.1
+RUN curl -fsSLo golangci-lint.tgz https://github.com/golangci/golangci-lint/releases/download/v1.17.1/golangci-lint-${GOLANGCILINTVERSION}-linux-amd64.tar.gz && \
+    echo "62693d3351858206af0bfe975f7f79a8ac9124502e8de7906f377c231f37f7d3  golangci-lint.tgz" | sha256sum -c && \
+    tar xzvf golangci-lint.tgz --strip 1 -C /usr/local/bin golangci-lint-${GOLANGCILINTVERSION}-linux-amd64/golangci-lint && \
+    rm golangci-lint.tgz;
 
 ARG revision
 LABEL maintainer="Weaveworks <help@weave.works>" \

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -32,8 +32,12 @@ RUN curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cl
     gcloud config set metrics/environment github_docker_image && \
     gcloud --version
 
-# Install Docker
-RUN curl -fsSL get.docker.com | VERSION=19.03.8 /bin/sh
+# Install Docker (client only)
+ENV DOCKERVERSION=19.03.8
+RUN curl -fsSLo docker.tgz https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKERVERSION}.tgz && \
+    echo "7f4115dc6a3c19c917f8b9664d7b51c904def1c984e082c4600097433323cf6f  docker.tgz" | sha256sum -c && \
+    tar xzvf docker.tgz --strip 1 -C /usr/local/bin docker/docker && \
+    rm docker.tgz;
 
 # Install gometalinter
 ENV GOMETALINTER_VERSION 2.0.11

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -15,10 +15,6 @@ RUN curl -fsSLo terraform.zip https://releases.hashicorp.com/terraform/0.11.10/t
     mv terraform /usr/bin && \
     rm -f terraform.zip
 
-# Install Ansible
-RUN pip install -U setuptools cffi && \
-    pip install ansible
-
 # Install Google Cloud SDK - borrowed from https://hub.docker.com/r/google/cloud-sdk/~/dockerfile/
 ENV CLOUD_SDK_VERSION 206.0.0
 ENV PATH /go/google-cloud-sdk/bin:$PATH

--- a/test/integration/bin/internal/provisioning/README.md
+++ b/test/integration/bin/internal/provisioning/README.md
@@ -4,11 +4,7 @@
 
 This project allows you to get hold of some machine either locally or on one of the below cloud providers:
 
-* Amazon Web Services
-* Digital Ocean
 * Google Cloud Platform
-
-You can then use these machines as is or run various Ansible playbooks from `../config_management` to set up Weave Net, Kubernetes, etc.
 
 ## Set up
 
@@ -51,4 +47,3 @@ Indeed, the functions defined in `setup.sh` are also exported as aliases, so you
 Other aliases are also defined, in order to make your life easier:
 
 * `tf_ssh`: to ease SSH-ing into the virtual machines, reading the username and IP address to use from Terraform, as well as setting default SSH options.
-* `tf_ansi`: to ease applying an Ansible playbook to a set of virtual machines, dynamically creating the inventory, as well as setting default SSH options.

--- a/test/integration/bin/internal/provisioning/setup.sh
+++ b/test/integration/bin/internal/provisioning/setup.sh
@@ -261,22 +261,3 @@ Available playbooks:
 EOF
     cat -n >&2 <<<"$(for file in "$(dirname "${BASH_SOURCE[0]}")"/../../config_management/*.yml; do basename "$file" | sed 's/.yml//'; done)"
 }
-
-# shellcheck disable=SC2155,SC2064
-function tf_ansi() {
-    [ -z "$1" ] && tf_ansi_usage "No Ansible playbook provided." && return 1
-    local id="$1"
-    shift # Drop the first argument to allow passing other arguments to Ansible using "$@" -- see below.
-    if [[ "$id" =~ ^[0-9]+$ ]]; then
-        local playbooks=(../../config_management/*.yml)
-        local path="${playbooks[(($id - 1))]}" # Select the ith entry in the list of playbooks (0-based).
-    else
-        local path="$(dirname "${BASH_SOURCE[0]}")/../../config_management/$id.yml"
-    fi
-    local inventory="$(mktemp /tmp/ansible_inventory_XXX)"
-    trap 'rm -f $inventory' SIGINT SIGTERM RETURN
-    echo -e "$(terraform output ansible_inventory)" >"$inventory"
-    [ ! -r "$path" ] && tf_ansi_usage "Ansible playbook not found: $path" && return 1
-    ansible-playbook "$@" -u "$(terraform output username)" -i "$inventory" --ssh-extra-args="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" "$path"
-}
-alias tf_ansi='tf_ansi'

--- a/test/integration/container/multimaster_test.go
+++ b/test/integration/container/multimaster_test.go
@@ -15,7 +15,6 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/weaveworks/wksctl/pkg/cluster/nodes"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -319,7 +318,11 @@ func TestMultimasterSetup(t *testing.T) {
 
 	var nodeList corev1.NodeList
 	for {
-		jsonOut := run(t, "kubectl", "get", "nodes", "-o", "json", fmt.Sprintf("--kubeconfig=%s", kubeconfig(out)))
+		jsonOut, stderr := doRun("kubectl", "get", "nodes", "-o", "json", fmt.Sprintf("--kubeconfig=%s", kubeconfig(out)))
+		if stderr != "" {
+			log.Warnf("error from kubectl; ignoring: %s", stderr)
+			continue
+		}
 		if err := json.Unmarshal([]byte(jsonOut), &nodeList); err != nil {
 			log.Warnf("Error deserialising output of kubectl get nodes: %s", err)
 		}
@@ -358,7 +361,7 @@ func TestMultimasterSetup(t *testing.T) {
 
 	if !t.Failed() { // Otherwise leave the footloose "VMs" & config files around for debugging purposes.
 		// Clean up:
-		defer run(t, "footloose", "delete", "-c", "../../../examples/footloose/centos7/docker/multimaster.yaml")
+		defer runIgnoreError(t, "footloose", "delete", "-c", "../../../examples/footloose/centos7/docker/multimaster.yaml")
 		defer os.Remove(dirName)
 		defer os.Remove(clusterYAML)
 		defer os.Remove(machinesYAML)
@@ -389,25 +392,30 @@ func port(t *testing.T, name string, defaultValue int) int {
 }
 
 func run(t *testing.T, name string, arg ...string) string {
-	return doRun(t, false, name, arg...)
+	t.Helper()
+	stdout, stderr := doRun(name, arg...)
+	if stderr != "" {
+		log.Infof("Command %s failed. STDOUT: %s\nSTDERR: %s", name, stdout, stderr)
+		t.FailNow()
+	}
+	return stdout
 }
 
 func runIgnoreError(t *testing.T, name string, arg ...string) string {
-	return doRun(t, true, name, arg...)
+	out, _ := doRun(name, arg...)
+	return out
 }
 
-func doRun(t *testing.T, ignoreError bool, name string, arg ...string) string {
-	log.Infof("running %s %s", name, arg)
-	cmd := exec.Command(name, arg...)
-	out, err := cmd.Output()
-	if err != nil && !ignoreError {
-		stderr := err.Error()
+func doRun(name string, arg ...string) (string, string) {
+	log.Infof("running %s %s", name, strings.Join(arg, " "))
+	out, err := exec.Command(name, arg...).Output()
+	if err != nil {
 		if ee, ok := err.(*exec.ExitError); ok {
-			stderr = string(ee.Stderr)
+			return string(out), string(ee.Stderr)
 		}
-		require.NoError(t, err, "Command %s failed. STDOUT: %s\nSTDERR: %s", cmd.Path, string(out), stderr)
+		return string(out), err.Error()
 	}
-	return string(out)
+	return string(out), ""
 }
 
 func sanitizeIP(ip string) string {


### PR DESCRIPTION
Remove some items from the image we don't need, like the Docker daemon and Ansible.
This makes the image about 700MB smaller.