### PR TITLE
Make sure extra kubelet arguments come out in a consistent order

### DIFF
--- a/pkg/plan/recipe/install_plans.go
+++ b/pkg/plan/recipe/install_plans.go
@@ -232,7 +232,7 @@ func BuildK8SPlan(kubernetesVersion string, kubeletNodeIP string, seLinuxInstall
 		result := cmdline
 		strs := []string{}
 		for name, value := range extraArgs {
-			strs = append(strs, fmt.Sprintf("--%s=%s", name, value))
+			strs = append(strs, fmt.Sprintf("--%s='%s'", name, value))
 		}
 		sort.Strings(strs)
 		for _, str := range strs {

--- a/pkg/plan/recipe/install_plans.go
+++ b/pkg/plan/recipe/install_plans.go
@@ -3,6 +3,7 @@ package recipe
 import (
 	"fmt"
 	"io/ioutil"
+	"sort"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/weaveworks/wksctl/pkg/apis/wksprovider/controller/manifests"
@@ -229,8 +230,13 @@ func BuildK8SPlan(kubernetesVersion string, kubeletNodeIP string, seLinuxInstall
 	}
 	processAdditionalArgs := func(cmdline string) string {
 		result := cmdline
+		strs := []string{}
 		for name, value := range extraArgs {
-			result = fmt.Sprintf("%s --%s=%s", result, name, value)
+			strs = append(strs, fmt.Sprintf("--%s=%s", name, value))
+		}
+		sort.Strings(strs)
+		for _, str := range strs {
+			result = fmt.Sprintf("%s %s", result, str)
 		}
 		return processCloudProvider(result)
 	}


### PR DESCRIPTION
A plan diff was occurring when extra kubelet arguments were generated in an inconsistent order due to hash iteration.