### PR TITLE
tidy up Footloose doc somewhat

### DIFF
--- a/docs/wks-and-footloose.md
+++ b/docs/wks-and-footloose.md
@@ -1,116 +1,125 @@
 # WKS and Footloose
 
+## Pre-requisites
+
 1. Pick a distro of your choice:
 
-   1. `centos7` (At the moment of writing, `centos7` is more mature)
-   2. `ubuntu1804`
+     1. `centos7` (At the moment of writing, `centos7` is more mature)
+     2. `ubuntu1804`
 
-   ```console
-   export DISTRO=centos7
-   ```
+     ```console
+     export DISTRO=centos7
+     ```
 
 1. Pick a backend of your choice:
 
-   1. `docker` (not real VMs, but can be used on Mac)
-   2. `ignite` (requires [Ignite](https://ignite.readthedocs.org) to be installed, and KVM functioning)
+     1. `docker` (not real VMs, but can be used on Mac)
+     2. `ignite` (requires [Ignite](https://ignite.readthedocs.org) to be installed, and KVM functioning)
 
-   ```console
-   export BACKEND=docker
-   ```
+     ```console
+     export BACKEND=docker
+     ```
 
 1. Install [footloose](https://github.com/weaveworks/footloose):
 
-   - Using Linux:
+     - Using Linux:
 
-     ```console
-     VERSION=$(curl -sSf https://api.github.com/repos/weaveworks/footloose/releases | jq -r '.[0].name')
-     curl -Lo footloose "https://github.com/weaveworks/footloose/releases/download/$VERSION/footloose-$VERSION-linux-x86_64"
-     chmod +x footloose
-     sudo mv footloose /usr/local/bin/
-     ```
+         ```console
+         VERSION=$(curl -sSf https://api.github.com/repos/weaveworks/footloose/releases | jq -r '.[0].name')
+         curl -Lo footloose "https://github.com/weaveworks/footloose/releases/download/$VERSION/footloose-$VERSION-linux-x86_64"
+         chmod +x footloose
+         sudo mv footloose /usr/local/bin/
+         ```
 
-   - Using macOS:
+     - Using macOS:
 
-     On macOS we provide a direct download and a homebrew tap:
+         On macOS we provide a direct download and a homebrew tap:
 
-     ```console
-     VERSION=$(curl -sSf https://api.github.com/repos/weaveworks/footloose/releases | jq -r '.[0].name')
-     curl --silent --location "https://github.com/weaveworks/footloose/releases/download/$VERSION/footloose-$VERSION-darwin-x86_64.tar.gz" | tar xz
-     sudo mv footloose /usr/local/bin
-     ```
+         ```console
+         VERSION=$(curl -sSf https://api.github.com/repos/weaveworks/footloose/releases | jq -r '.[0].name')
+         curl --silent --location "https://github.com/weaveworks/footloose/releases/download/$VERSION/footloose-$VERSION-darwin-x86_64.tar.gz" | tar xz
+         sudo mv footloose /usr/local/bin
+         ```
 
-     or
+         or
 
-     ```console
-     brew tap weaveworks/tap
-     brew install weaveworks/tap/footloose
-     ```
+         ```console
+         brew tap weaveworks/tap
+         brew install weaveworks/tap/footloose
+         ```
 
-1. Start two machines using `footloose`:
+## Getting started
 
-   These commands assume you are in the `examples/footloose` directory.
+### Starting the machines
 
-   ```console
-   $ footloose create -c ${DISTRO}/${BACKEND}/singlemaster.yaml
-   INFO[0000] Image: quay.io/footloose/centos7 present locally
-   INFO[0000] Creating machine: centos-singlemaster-node0 ...
-   INFO[0001] Creating machine: centos-singlemaster-node1 ...
-   ```
+Here we will start two machines using `footloose`:
 
-   You should now see the Container Machines running with `docker ps` or `ignite ps` (depending on your backend):
+These commands assume you are in the `examples/footloose` directory.
 
-   ```console
-   $ docker ps
-   CONTAINER ID        IMAGE                     COMMAND             CREATED             STATUS              PORTS                                          NAMES
-   ab4f4b75f63d        quay.io/wksctl/vm-centos7 "/sbin/init"        5 seconds ago         Up 4 seconds          0.0.0.0:2223->22/tcp, 0.0.0.0:6444->6443/tcp   cluster-node1
-   0ce280129e79        quay.io/wksctl/vm-centos7 "/sbin/init"        6 seconds ago         Up 5 seconds          0.0.0.0:6443->6443/tcp, 0.0.0.0:2222->22/tcp   cluster-node0
-   ```
+```console
+$ footloose create -c ${DISTRO}/${BACKEND}/singlemaster.yaml
+INFO[0000] Image: quay.io/footloose/centos7 present locally
+INFO[0000] Creating machine: centos-singlemaster-node0 ...
+INFO[0001] Creating machine: centos-singlemaster-node1 ...
+```
 
-   or:
+You should now see the Container Machines running with `docker ps` or `ignite ps` (depending on your backend):
 
-   ```console
-   $ ignite ps
-   VM ID			IMAGE				KERNEL					SIZE	CPUS	MEMORY		CREATED	STATUS	IPS		PORTS						NAME
-   3fbe4611682b3e16	weaveworks/ignite-centos:latest	weaveworks/ignite-kernel:4.19.47	4.0 GB	2	1024.0 MB	10m ago	Up 10m	172.17.0.3	0.0.0.0:30444->30443/tcp, 0.0.0.0:30081->30080/tcp, 0.0.0.0:2223->22/tcp, 0.0.0.0:6444->6443/tcp	centos-singlemaster-node1
-   b4fdde36eb122804	weaveworks/ignite-centos:latest	weaveworks/ignite-kernel:4.19.47	4.0 GB	2	1024.0 MB	10m ago	Up 10m	172.17.0.2	0.0.0.0:2222->22/tcp, 0.0.0.0:6443->6443/tcp, 0.0.0.0:30443->30443/tcp, 0.0.0.0:30080->30080/tcp	centos-singlemaster-node0
-   ```
+```console
+$ docker ps
+CONTAINER ID        IMAGE                     COMMAND             CREATED             STATUS              PORTS                                          NAMES
+ab4f4b75f63d        quay.io/wksctl/vm-centos7 "/sbin/init"        5 seconds ago         Up 4 seconds          0.0.0.0:2223->22/tcp, 0.0.0.0:6444->6443/tcp   cluster-node1
+0ce280129e79        quay.io/wksctl/vm-centos7 "/sbin/init"        6 seconds ago         Up 5 seconds          0.0.0.0:6443->6443/tcp, 0.0.0.0:2222->22/tcp   cluster-node0
+```
 
-   In case you would like to ssh into a machine e.g. `node0`, run:
+or:
 
-   ```console
-   footloose ssh -c ${DISTRO}/${BACKEND}/singlemaster.yaml root@node0
-   ```
+```console
+$ ignite ps
+VM ID			IMAGE				KERNEL					SIZE	CPUS	MEMORY		CREATED	STATUS	IPS		PORTS						NAME
+3fbe4611682b3e16	weaveworks/ignite-centos:latest	weaveworks/ignite-kernel:4.19.47	4.0 GB	2	1024.0 MB	10m ago	Up 10m	172.17.0.3	0.0.0.0:30444->30443/tcp, 0.0.0.0:30081->30080/tcp, 0.0.0.0:2223->22/tcp, 0.0.0.0:6444->6443/tcp	centos-singlemaster-node1
+b4fdde36eb122804	weaveworks/ignite-centos:latest	weaveworks/ignite-kernel:4.19.47	4.0 GB	2	1024.0 MB	10m ago	Up 10m	172.17.0.2	0.0.0.0:2222->22/tcp, 0.0.0.0:6443->6443/tcp, 0.0.0.0:30443->30443/tcp, 0.0.0.0:30080->30080/tcp	centos-singlemaster-node0
+```
 
-   as the default user name is `root` for both backends.
+In case you would like to ssh into a machine e.g. `node0`, run:
+
+```console
+footloose ssh -c ${DISTRO}/${BACKEND}/singlemaster.yaml root@node0
+```
+
+as the default user name is `root` for both backends.
+
+### Starting the cluster
+
 
 1. Run `wksctl apply`:
 
-   ```console
-   wksctl apply \
-    --machines=machines.yaml \
-    --cluster=cluster.yaml \
-    --verbose
-   ```
+     ```console
+     wksctl apply \
+      --machines=machines.yaml \
+      --cluster=cluster.yaml \
+      --verbose
+     ```
 
 1. Run `wksctl kubeconfig` to be able to connect to the cluster:
 
-   ```console
-   $ wksctl kubeconfig --cluster=cluster.yaml
-   The kubeconfig file at "/home/dinos/.kube/config" has been updated
-   $ kubectl get nodes
-   NAME               STATUS   ROLES    AGE   VERSION
-   b4fdde36eb122804   Ready    master   77s   v1.14.1
-   $ kubectl get pods --all-namespaces
-   NAMESPACE     NAME                              READY   STATUS    RESTARTS   AGE
-   kube-system   coredns-86c58d9df4-26gv9          1/1     Running   0          55s
-   kube-system   coredns-86c58d9df4-mb4h9          1/1     Running   0          55s
-   kube-system   etcd-13e2dc14bf30                 1/1     Running   0          6s
-   kube-system   kube-apiserver-13e2dc14bf30       1/1     Running   0          8s
-   kube-system   kube-proxy-l2fv7                  1/1     Running   0          55s
-   kube-system   kube-scheduler-13e2dc14bf30       1/1     Running   0          9s
-   kube-system   weave-net-n7lqb                   2/2     Running   0          55s
-   system        wks-controller-654d7cfb7c-47f9g   1/1     Running   0          54s
-   ```
+     ```console
+     $ wksctl kubeconfig --cluster=cluster.yaml
+     The kubeconfig file at "/home/dinos/.kube/config" has been updated
+     $ kubectl get nodes
+     NAME               STATUS   ROLES    AGE   VERSION
+     b4fdde36eb122804   Ready    master   77s   v1.14.1
+     $ kubectl get pods --all-namespaces
+     NAMESPACE     NAME                              READY   STATUS    RESTARTS   AGE
+     kube-system   coredns-86c58d9df4-26gv9          1/1     Running   0          55s
+     kube-system   coredns-86c58d9df4-mb4h9          1/1     Running   0          55s
+     kube-system   etcd-13e2dc14bf30                 1/1     Running   0          6s
+     kube-system   kube-apiserver-13e2dc14bf30       1/1     Running   0          8s
+     kube-system   kube-proxy-l2fv7                  1/1     Running   0          55s
+     kube-system   kube-scheduler-13e2dc14bf30       1/1     Running   0          9s
+     kube-system   weave-net-n7lqb                   2/2     Running   0          55s
+     system        wks-controller-654d7cfb7c-47f9g   1/1     Running   0          54s
+     ```
 
 ## Multi-masters
 


### PR DESCRIPTION
![Screenshot from 2020-05-15 11-33-59](https://user-images.githubusercontent.com/1346979/82036246-f22a1780-96a0-11ea-8d12-e60015aebba9.png)

The enumeration in the Footloose doc was all over the place. I think it's `mkdocs` that requires a slightly different indentation to bring things out the right way.

I broke up the doc into sections, so it gets easier to read and we have less to worry about indenting things over multiple levels.