### PR TITLE
Return non-zero if error occurs in applying seed node plan

### DIFF
--- a/cmd/wksctl/apply/apply.go
+++ b/cmd/wksctl/apply/apply.go
@@ -1,7 +1,6 @@
 package apply
 
 import (
-	"fmt"
 	"path/filepath"
 	"strings"
 
@@ -152,7 +151,8 @@ func (a *Applier) initiateCluster(clusterManifestPath, machinesManifestPath stri
 	if err != nil {
 		return errors.Wrap(err, "failed to apply the cluster's image repository to the WKS controller's image")
 	}
-	res := installer.SetupSeedNode(wksos.SeedNodeParams{
+
+	if err := installer.SetupSeedNode(wksos.SeedNodeParams{
 		PublicIP:             sp.GetMasterPublicAddress(),
 		PrivateIP:            sp.GetMasterPrivateAddress(),
 		ClusterManifestPath:  clusterManifestPath,
@@ -182,11 +182,7 @@ func (a *Applier) initiateCluster(clusterManifestPath, machinesManifestPath stri
 		AdditionalSANs:       sp.ClusterSpec.APIServer.AdditionalSANs,
 		Namespace:            ns,
 		AddonNamespaces:      addonNamespaces,
-	})
-
-	fmt.Printf("RES: %#v\n", res)
-
-	if err := res; err != nil {
+	}); err != nil {
 		return errors.Wrapf(err, "failed to set up seed node (%s)", sp.GetMasterPublicAddress())
 	}
 

--- a/cmd/wksctl/apply/apply.go
+++ b/cmd/wksctl/apply/apply.go
@@ -1,6 +1,7 @@
 package apply
 
 import (
+	"fmt"
 	"path/filepath"
 	"strings"
 
@@ -149,9 +150,9 @@ func (a *Applier) initiateCluster(clusterManifestPath, machinesManifestPath stri
 	// TODO(damien): Transform the controller image into an addon.
 	controllerImage, err := addons.UpdateImage(a.Params.controllerImage, sp.ClusterSpec.ImageRepository)
 	if err != nil {
-		errors.Wrap(err, "failed to apply the cluster's image repository to the WKS controller's image")
+		return errors.Wrap(err, "failed to apply the cluster's image repository to the WKS controller's image")
 	}
-	if err := installer.SetupSeedNode(wksos.SeedNodeParams{
+	res := installer.SetupSeedNode(wksos.SeedNodeParams{
 		PublicIP:             sp.GetMasterPublicAddress(),
 		PrivateIP:            sp.GetMasterPrivateAddress(),
 		ClusterManifestPath:  clusterManifestPath,
@@ -181,7 +182,11 @@ func (a *Applier) initiateCluster(clusterManifestPath, machinesManifestPath stri
 		AdditionalSANs:       sp.ClusterSpec.APIServer.AdditionalSANs,
 		Namespace:            ns,
 		AddonNamespaces:      addonNamespaces,
-	}); err != nil {
+	})
+
+	fmt.Printf("RES: %#v\n", res)
+
+	if err := res; err != nil {
 		return errors.Wrapf(err, "failed to set up seed node (%s)", sp.GetMasterPublicAddress())
 	}
 

--- a/pkg/apis/wksprovider/machine/os/os.go
+++ b/pkg/apis/wksprovider/machine/os/os.go
@@ -490,6 +490,11 @@ func (o OS) createSeedNodePlanConfigMapManifest(params SeedNodeParams, providerS
 }
 
 func (o OS) applySeedNodePlan(p *plan.Plan) error {
+	defer func() {
+		if val := recover(); val != nil {
+			fmt.Printf("RECOVERED: %#v\n", val)
+		}
+	}()
 	err := p.Undo(o.runner, plan.EmptyState)
 	if err != nil {
 		log.Infof("Pre-plan cleanup failed:\n%s\n", err)

--- a/pkg/apis/wksprovider/machine/os/os.go
+++ b/pkg/apis/wksprovider/machine/os/os.go
@@ -499,6 +499,7 @@ func (o OS) applySeedNodePlan(p *plan.Plan) error {
 	_, err = p.Apply(o.runner, plan.EmptyDiff())
 	if err != nil {
 		log.Errorf("Apply of Plan failed:\n%s\n", err)
+		return err
 	}
 	return nil
 }

--- a/pkg/apis/wksprovider/machine/os/os.go
+++ b/pkg/apis/wksprovider/machine/os/os.go
@@ -490,11 +490,6 @@ func (o OS) createSeedNodePlanConfigMapManifest(params SeedNodeParams, providerS
 }
 
 func (o OS) applySeedNodePlan(p *plan.Plan) error {
-	defer func() {
-		if val := recover(); val != nil {
-			fmt.Printf("RECOVERED: %#v\n", val)
-		}
-	}()
 	err := p.Undo(o.runner, plan.EmptyState)
 	if err != nil {
 		log.Infof("Pre-plan cleanup failed:\n%s\n", err)

--- a/pkg/plan/plan.go
+++ b/pkg/plan/plan.go
@@ -872,6 +872,7 @@ func (p *Plan) applyResources(g *graph, endpoints []string, diff *Diff, runner R
 	result := make(map[string]ValidityTree)
 	// ascend the graph propagating validity
 	if err := p.propagate(sorted, connectors, diff, runner); err != nil {
+		result["top"] = ValidityTree{ResourceID: "top", ValidityStatus: Invalid}
 		return result
 	}
 	// Wait for all results to reach the top

--- a/test/integration/spawn/executor.go
+++ b/test/integration/spawn/executor.go
@@ -103,7 +103,6 @@ func (e *Executor) handStream(entry *Entry, kind stream, reader io.Reader) error
 }
 
 func exitCode(err error) (int, error) {
-	fmt.Printf("ERR: %#v\n", err)
 	if err == nil {
 		return 0, nil
 	}

--- a/test/integration/spawn/executor.go
+++ b/test/integration/spawn/executor.go
@@ -103,6 +103,7 @@ func (e *Executor) handStream(entry *Entry, kind stream, reader io.Reader) error
 }
 
 func exitCode(err error) (int, error) {
+	fmt.Printf("ERR: %#v\n", err)
 	if err == nil {
 		return 0, nil
 	}

--- a/test/integration/test/apply_test.go
+++ b/test/integration/test/apply_test.go
@@ -457,7 +457,7 @@ func TestApply(t *testing.T) {
 	assert.Equal(t, 1, run.ExitCode())
 
 	// Install the Cluster.
-	run, err := apply(exe, "--cluster="+clusterManifestPath, "--machines="+machinesManifestPath, "--namespace=default",
+	run, err = apply(exe, "--cluster="+clusterManifestPath, "--machines="+machinesManifestPath, "--namespace=default",
 		"--config-directory="+configDir, "--sealed-secret-key="+configPath("ss.key"), "--sealed-secret-cert="+configPath("ss.cert"),
 		"--verbose=true", "--ssh-key="+sshKeyPath)
 	assert.NoError(t, err)

--- a/test/integration/test/apply_test.go
+++ b/test/integration/test/apply_test.go
@@ -400,7 +400,6 @@ func writeTmpFile(runner *ssh.Client, inputFilename, outputFilename string) erro
 
 func TestApply(t *testing.T) {
 	exe := run.NewExecutor()
-	exe.showOutput = true
 
 	// Prepare the machines manifest from terraform output.
 	terraform, err := newTerraformOutputFromFile(options.terraform.outputPath)

--- a/test/integration/test/apply_test.go
+++ b/test/integration/test/apply_test.go
@@ -410,6 +410,7 @@ func TestApply(t *testing.T) {
 	writeYamlManifest(t, machines, configPath("machines.yaml"))
 
 	spec := machineSpec(t, &machines.Items[0])
+	// Generate bad version to check failure return codes
 	savedAddress := spec.Private.Address
 	spec.Private.Address = "192.168.111.111"
 	codec, err := baremetalspecv1.NewCodec()
@@ -418,6 +419,7 @@ func TestApply(t *testing.T) {
 	assert.NoError(t, err)
 	machines.Items[0].Spec.ProviderSpec = *encodedSpec
 	writeYamlManifest(t, machines, configPath("badmachines.yaml"))
+	// Restore valid config
 	spec.Private.Address = savedAddress
 	encodedSpec, err = codec.EncodeToProviderSpec(spec)
 	assert.NoError(t, err)

--- a/test/integration/test/apply_test.go
+++ b/test/integration/test/apply_test.go
@@ -459,7 +459,7 @@ func TestApply(t *testing.T) {
 	// First test that bad apply returns non-zero exit code
 	badMachinesManifestPath := configPath("badmachines.yaml")
 	// Fail to install the cluster.
-	run, err := apply(exe, "--cluster="+clusterManifestPath, "--machines="+badMachinesManifestPath, "--namespace=default",
+	run, _ := apply(exe, "--cluster="+clusterManifestPath, "--machines="+badMachinesManifestPath, "--namespace=default",
 		"--config-directory="+configDir, "--sealed-secret-key="+configPath("ss.key"), "--sealed-secret-cert="+configPath("ss.cert"),
 		"--verbose=true", "--ssh-key="+sshKeyPath)
 	assert.Equal(t, 1, run.ExitCode())

--- a/test/integration/test/apply_test.go
+++ b/test/integration/test/apply_test.go
@@ -462,7 +462,6 @@ func TestApply(t *testing.T) {
 	run, err := apply(exe, "--cluster="+clusterManifestPath, "--machines="+badMachinesManifestPath, "--namespace=default",
 		"--config-directory="+configDir, "--sealed-secret-key="+configPath("ss.key"), "--sealed-secret-cert="+configPath("ss.cert"),
 		"--verbose=true", "--ssh-key="+sshKeyPath)
-	assert.Error(t, err)
 	assert.Equal(t, 1, run.ExitCode())
 
 	// Install the Cluster.

--- a/test/integration/test/apply_test.go
+++ b/test/integration/test/apply_test.go
@@ -400,6 +400,7 @@ func writeTmpFile(runner *ssh.Client, inputFilename, outputFilename string) erro
 
 func TestApply(t *testing.T) {
 	exe := run.NewExecutor()
+	exe.showOutput = true
 
 	// Prepare the machines manifest from terraform output.
 	terraform, err := newTerraformOutputFromFile(options.terraform.outputPath)


### PR DESCRIPTION
Two issues prevented a non-zero exit code from being returned on failure:

1. The plan invocation just logged an error and returned nil
2. A failure in a sub-plan could return an empty validation struct which looked like no error