### PR TITLE
Include error message from 'kubectl apply'

### DIFF
--- a/pkg/plan/resource/kubectl_apply.go
+++ b/pkg/plan/resource/kubectl_apply.go
@@ -170,7 +170,7 @@ func kubectlRemoteApply(remoteURL string, runner plan.Runner) error {
 
 	if stdouterr, err := runner.RunCommand(withoutProxy(cmd), nil); err != nil {
 		log.WithField("stdouterr", stdouterr).WithField("URL", remoteURL).Debug(fmt.Sprintf("failed to apply Kubernetes manifest"))
-		return errors.Wrapf(err, "failed to apply manifest %q", remoteURL)
+		return errors.Wrapf(err, "failed to apply manifest %s; output %s", remoteURL, stdouterr)
 	}
 	return nil
 }


### PR DESCRIPTION
To illustrate: this is what I was seeing before:
```
kubectl apply: failed to apply manifest "/tmp/machinesmanifestDHS9BJ76Ww": command exited with 1
```

And after:
```
kubectl apply: failed to apply manifest /tmp/machinesmanifestTBovn8Wyqt; output baremetalmachine.cluster.weave.works/master-0 created
baremetalmachine.cluster.weave.works/master-1 created
Error from server (Invalid): error when creating "/tmp/machinesmanifestTBovn8Wyqt": Machine.cluster.x-k8s.io "master-0" is invalid: spec.clusterName: Invalid value: "": spec.clusterName in body should be at least 1 chars long
Error from server (Invalid): error when creating "/tmp/machinesmanifestTBovn8Wyqt": Machine.cluster.x-k8s.io "master-1" is invalid: spec.clusterName: Invalid value: "": spec.clusterName in body should be at least 1 chars long
Error from server (Invalid): error when creating "/tmp/machinesmanifestTBovn8Wyqt": Machine.cluster.x-k8s.io "worker-0" is invalid: spec.clusterName: Invalid value: "": spec.clusterName in body should be at least 1 chars long
baremetalmachine.cluster.weave.works/worker-0 created
: command exited with 1
```

Note that I didn't use `%q` because it's even harder to read with a bunch of `\"`s and `\n`s.
I would argue we don't need to put the name of the temp file in the message either because it's deleted by the time we hear about it, but that's a minor point.