### PR TITLE
[WKP-679] rhel install docker fails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /examples/.vagrant
 /rpm/output
 /test/resource/tests
+/test/integration/test/kubectl
 
 # Ignore generated binaries
 /cmd/controller/controller

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,6 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
+github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
@@ -303,8 +304,6 @@ github.com/thanhpk/randstr v0.0.0-20190104161604-ac5b2d62bffb h1:Ih4dkfHqv5m1/CH
 github.com/thanhpk/randstr v0.0.0-20190104161604-ac5b2d62bffb/go.mod h1:M/H2P1eNLZzlDwAzpkkkUvoyNNMbzRGhESZuEQk3r0U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
-github.com/weaveworks/footloose v0.0.0-20190829132911-efbcbb7a6390 h1:+eeBhTQ/e64tnpCm2fQa2lanFJPKzBq5de6ApW6rDdc=
-github.com/weaveworks/footloose v0.0.0-20190829132911-efbcbb7a6390/go.mod h1:nOh5HQLDNC5MgZTPXbfnp+ChzAGRSkKopJmSNIGvi6w=
 github.com/weaveworks/footloose v0.0.0-20190903132036-efbcbb7a6390 h1:kFi0CaTblX4lM4Oi9KeZmcz3eo7NsmwNEXgQrVkVXHw=
 github.com/weaveworks/footloose v0.0.0-20190903132036-efbcbb7a6390/go.mod h1:nOh5HQLDNC5MgZTPXbfnp+ChzAGRSkKopJmSNIGvi6w=
 github.com/weaveworks/go-checkpoint v0.0.0-20170503165305-ebbb8b0518ab h1:mW+hgchD9qUUBqnuaDBj7BkcpFPk/FxeFcUFI5lvvUw=

--- a/pkg/plan/recipe/install_plans.go
+++ b/pkg/plan/recipe/install_plans.go
@@ -90,7 +90,20 @@ func BuildCRIPlan(criSpec *baremetalspecv1.ContainerRuntime, cfg *envcfg.EnvSpec
 	IsDockerOnCentOS := false
 	// Docker runtime
 	switch pkgType {
-	case resource.PkgTypeRPM, resource.PkgTypeRHEL:
+	case resource.PkgTypeRHEL:
+		b.AddResource("install:container-selinux",
+			&resource.Run{Script: object.String("yum install -y http://mirror.centos.org/centos/7/extras/x86_64/Packages/container-selinux-2.107-1.el7_6.noarch.rpm")})
+
+		b.AddResource("install:docker",
+			&resource.RPM{Name: criSpec.Package, Version: criSpec.Version},
+			plan.DependOn("install:container-selinux"))
+
+		// SELinux will be here along with docker and containerd-selinux packages
+		IsDockerOnCentOS = false
+
+	case resource.PkgTypeRPM:
+		b.AddResource("install:container-selinux",
+			&resource.Run{Script: object.String("yum install -y http://mirror.centos.org/centos/7/extras/x86_64/Packages/container-selinux-2.107-1.el7_6.noarch.rpm")})
 		b.AddResource("install:docker", &resource.RPM{Name: criSpec.Package, Version: criSpec.Version})
 		// SELinux will be here along with docker and containerd-selinux packages
 		IsDockerOnCentOS = true

--- a/pkg/plan/recipe/install_plans.go
+++ b/pkg/plan/recipe/install_plans.go
@@ -94,27 +94,19 @@ func BuildCRIPlan(criSpec *baremetalspecv1.ContainerRuntime, cfg *envcfg.EnvSpec
 	case resource.PkgTypeRHEL:
 		b.AddResource("install:container-selinux",
 			&resource.Run{
-				Script:     object.String("yum install -y http://mirror.centos.org/centos/7/extras/x86_64/Packages/container-selinux-2.107-1.el7_6.noarch.rpm"),
-				UndoScript: object.String("yum remove -y container-selinux")})
+				Script:     object.String("yum install -y http://mirror.centos.org/centos/7/extras/x86_64/Packages/container-selinux-2.107-1.el7_6.noarch.rpm || true"),
+				UndoScript: object.String("yum remove -y container-selinux || true")})
 
 		b.AddResource("install:docker",
 			&resource.RPM{Name: criSpec.Package, Version: criSpec.Version},
 			plan.DependOn("install:container-selinux"))
 
 		// SELinux will be here along with docker and containerd-selinux packages
-		IsDockerOnCentOS = false
+		IsDockerOnCentOS = true
 
 	case resource.PkgTypeRPM:
-		b.AddResource("install:container-selinux",
-			&resource.Run{
-				Script:     object.String("yum install -y http://mirror.centos.org/centos/7/extras/x86_64/Packages/container-selinux-2.107-1.el7_6.noarch.rpm"),
-				UndoScript: object.String("yum remove -y container-selinux"),
-			},
-		)
-
 		b.AddResource("install:docker",
-			&resource.RPM{Name: criSpec.Package, Version: criSpec.Version},
-			plan.DependOn("install:container-selinux"))
+			&resource.RPM{Name: criSpec.Package, Version: criSpec.Version})
 
 		// SELinux will be here along with docker and containerd-selinux packages
 		IsDockerOnCentOS = true

--- a/pkg/plan/recipe/install_plans.go
+++ b/pkg/plan/recipe/install_plans.go
@@ -88,11 +88,14 @@ func BuildCRIPlan(criSpec *baremetalspecv1.ContainerRuntime, cfg *envcfg.EnvSpec
 	}
 
 	IsDockerOnCentOS := false
+
 	// Docker runtime
 	switch pkgType {
 	case resource.PkgTypeRHEL:
 		b.AddResource("install:container-selinux",
-			&resource.Run{Script: object.String("yum install -y http://mirror.centos.org/centos/7/extras/x86_64/Packages/container-selinux-2.107-1.el7_6.noarch.rpm")})
+			&resource.Run{
+				Script:     object.String("yum install -y http://mirror.centos.org/centos/7/extras/x86_64/Packages/container-selinux-2.107-1.el7_6.noarch.rpm"),
+				UndoScript: object.String("yum remove -y container-selinux")})
 
 		b.AddResource("install:docker",
 			&resource.RPM{Name: criSpec.Package, Version: criSpec.Version},
@@ -103,8 +106,16 @@ func BuildCRIPlan(criSpec *baremetalspecv1.ContainerRuntime, cfg *envcfg.EnvSpec
 
 	case resource.PkgTypeRPM:
 		b.AddResource("install:container-selinux",
-			&resource.Run{Script: object.String("yum install -y http://mirror.centos.org/centos/7/extras/x86_64/Packages/container-selinux-2.107-1.el7_6.noarch.rpm")})
-		b.AddResource("install:docker", &resource.RPM{Name: criSpec.Package, Version: criSpec.Version})
+			&resource.Run{
+				Script:     object.String("yum install -y http://mirror.centos.org/centos/7/extras/x86_64/Packages/container-selinux-2.107-1.el7_6.noarch.rpm"),
+				UndoScript: object.String("yum remove -y container-selinux"),
+			},
+		)
+
+		b.AddResource("install:docker",
+			&resource.RPM{Name: criSpec.Package, Version: criSpec.Version},
+			plan.DependOn("install:container-selinux"))
+
 		// SELinux will be here along with docker and containerd-selinux packages
 		IsDockerOnCentOS = true
 	case resource.PkgTypeDeb:


### PR DESCRIPTION
* fixes an issue where install of docker-ce fails on RHEL7 due to a dependency failure for container-selinux
* container-selinux needs to be newer
* plan installs container-selinux version 2.107-1.el7_6.noarch.rpm via yum before proceeding to install docker-ce