### PR TITLE
Use the correct "installer" to associate a standard node plan with the initial master node

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -482,6 +482,7 @@ modernc.org/strutil v1.0.0/go.mod h1:lstksw84oURvj9y3tn8lGvRxyRC1S2+g5uuIzNfIOBs
 modernc.org/xc v1.0.0/go.mod h1:mRNCo0bvLjGhHO9WsyuKVU4q0ceiDDDoEeWDJHrNx8I=
 sigs.k8s.io/cluster-api v0.0.0-20181211193542-3547f8dd9307 h1:JZJOppRhof1HiN8OBmn7DWZKjI0QhqpOCZePcyDWP3o=
 sigs.k8s.io/cluster-api v0.0.0-20181211193542-3547f8dd9307/go.mod h1:aEXstFx3krpj6/AOcV/rOP2VLKdrtSNUMDR2Kmt6YSs=
+sigs.k8s.io/cluster-api v0.3.6 h1:Md//qVTwPvJFIBzQ8Mnsro1510x4UFtOyx4t6sPoDnM=
 sigs.k8s.io/controller-runtime v0.1.12 h1:ovDq28E64PeY1yR+6H7DthakIC09soiDCrKvfP2tPYo=
 sigs.k8s.io/controller-runtime v0.1.12/go.mod h1:HFAYoOh6XMV+jKF1UjFwrknPbowfyHEHHRdJMf2jMX8=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=


### PR DESCRIPTION
When the first node is created or updated by the wks controller, a standard node plan is created for the initial master so that it can be compared to any future update. The plan was being created based on the OS of the new node being created/updated instead of the OS of the initial master. This PR finds the OS of the initial master and creates a new installer before generating a plan.
