### PR TITLE
Fail parsing if manifest lacks Cluster or BareMetalCluster definition

### DIFF
--- a/pkg/specs/parse_test.go
+++ b/pkg/specs/parse_test.go
@@ -1,0 +1,57 @@
+package specs
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	baremetalspecv1 "github.com/weaveworks/wksctl/pkg/baremetal/v1alpha3"
+	"io/ioutil"
+	"k8s.io/client-go/kubernetes/scheme"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	"strings"
+	"testing"
+)
+
+const clusterMissingClusterDefinition = `
+apiVersion: "cluster.weave.works/v1alpha3"
+kind: "BareMetalCluster"
+metadata:
+ name: example
+spec:
+ user: "vagrant"
+`
+
+const clusterMissingBareMetalClusterDefinition = `
+apiVersion: "cluster.x-k8s.io/v1alpha3"
+kind: Cluster
+metadata:
+ name: example
+spec:
+ clusterNetwork:
+   services:
+     cidrBlocks: ["10.96.0.0/12"]
+   pods:
+     cidrBlocks: ["192.168.0.0/16"]
+   infrastructureRef:
+     kind: BareMetalCluster
+     name: example
+`
+
+func mergeObjects(a string, b string) string {
+	return fmt.Sprintf("%s---%s", a, b)
+}
+
+func parseConfig(s string) (err error) {
+	r := ioutil.NopCloser(strings.NewReader(s))
+	_, _, err = ParseCluster(r)
+	return
+}
+
+func TestParseCluster(t *testing.T) {
+	assert.NoError(t, clusterv1.AddToScheme(scheme.Scheme))
+	assert.NoError(t, baremetalspecv1.AddToScheme(scheme.Scheme))
+	assert.NoError(t, parseConfig(mergeObjects(clusterMissingBareMetalClusterDefinition, clusterMissingClusterDefinition)))
+
+	// Verify that the objects individually don't result in a successful parse
+	assert.Error(t, parseConfig(clusterMissingClusterDefinition))
+	assert.Error(t, parseConfig(clusterMissingBareMetalClusterDefinition))
+}

--- a/pkg/specs/specs.go
+++ b/pkg/specs/specs.go
@@ -110,6 +110,15 @@ func ParseCluster(r io.ReadCloser) (cluster *clusterv1.Cluster, bmc *baremetalsp
 			return nil, nil, errors.Errorf("unexpected type %T", v)
 		}
 	}
+
+	if cluster == nil {
+		return nil, nil, errors.New("parsed cluster manifest lacks Cluster definition")
+	}
+
+	if bmc == nil {
+		return nil, nil, errors.New("parsed cluster manifest lacks BareMetalCluster definition")
+	}
+
 	return
 }
 


### PR DESCRIPTION
In case the the manifest lacks either the `Cluster` or `BareMetalCluster` definition, the parser will happily output a nil pointer to the validator, which causes e.g. `wksctl apply` to dereference panic. This adds a check to verify both definitions are present, and also provides a unit test for it.