### PR TITLE
Update Footloose images to ensure machine id and uuid are unique

### DIFF
--- a/examples/footloose/centos7/docker/multimaster.yaml
+++ b/examples/footloose/centos7/docker/multimaster.yaml
@@ -2,18 +2,18 @@ cluster:
   name: centos-multimaster
   privateKey: cluster-key
 machines:
-- count: 4
-  spec:
-    image: quay.io/footloose/centos7:0.6.0
-    name: node%d
-    portMappings:
-    - containerPort: 22
-      hostPort: 2222
-    - containerPort: 6443
-      hostPort: 6443
-    # The below is required for dockerd to run smoothly.
-    # See also: https://github.com/weaveworks/footloose#running-dockerd-in-container-machines
-    privileged: true
-    volumes:
-    - type: volume
-      destination: /var/lib/docker
+  - count: 4
+    spec:
+      image: quay.io/footloose/centos7:0.6.3
+      name: node%d
+      portMappings:
+        - containerPort: 22
+          hostPort: 2222
+        - containerPort: 6443
+          hostPort: 6443
+      # The below is required for dockerd to run smoothly.
+      # See also: https://github.com/weaveworks/footloose#running-dockerd-in-container-machines
+      privileged: true
+      volumes:
+        - type: volume
+          destination: /var/lib/docker

--- a/examples/footloose/centos7/docker/singlemaster.yaml
+++ b/examples/footloose/centos7/docker/singlemaster.yaml
@@ -2,22 +2,22 @@ cluster:
   name: centos-singlemaster
   privateKey: cluster-key
 machines:
-- count: 2
-  spec:
-    image: quay.io/footloose/centos7:0.3.0
-    name: node%d
-    portMappings:
-    - containerPort: 22
-      hostPort: 2222
-    - containerPort: 6443
-      hostPort: 6443
-    - containerPort: 30443
-      hostPort: 30443
-    - containerPort: 30080
-      hostPort: 30080
-    # The below is required for dockerd to run smoothly.
-    # See also: https://github.com/weaveworks/footloose#running-dockerd-in-container-machines
-    privileged: true
-    volumes:
-    - type: volume
-      destination: /var/lib/docker
+  - count: 2
+    spec:
+      image: quay.io/footloose/centos7:0.6.3
+      name: node%d
+      portMappings:
+        - containerPort: 22
+          hostPort: 2222
+        - containerPort: 6443
+          hostPort: 6443
+        - containerPort: 30443
+          hostPort: 30443
+        - containerPort: 30080
+          hostPort: 30080
+      # The below is required for dockerd to run smoothly.
+      # See also: https://github.com/weaveworks/footloose#running-dockerd-in-container-machines
+      privileged: true
+      volumes:
+        - type: volume
+          destination: /var/lib/docker

--- a/examples/footloose/ubuntu1804/docker/multimaster.yaml
+++ b/examples/footloose/ubuntu1804/docker/multimaster.yaml
@@ -4,7 +4,7 @@ cluster:
 machines:
 - count: 4
   spec:
-    image: quay.io/footloose/ubuntu18.04:0.4.0
+    image: quay.io/footloose/ubuntu18.04:0.6.3
     name: node%d
     portMappings:
     - containerPort: 22

--- a/examples/footloose/ubuntu1804/docker/singlemaster.yaml
+++ b/examples/footloose/ubuntu1804/docker/singlemaster.yaml
@@ -4,7 +4,7 @@ cluster:
 machines:
 - count: 2
   spec:
-    image: quay.io/footloose/ubuntu18.04:0.4.0
+    image: quay.io/footloose/ubuntu18.04:0.6.3
     name: node%d
     portMappings:
     - containerPort: 22

--- a/pkg/apis/wksprovider/controller/wksctl/machine_actuator.go
+++ b/pkg/apis/wksprovider/controller/wksctl/machine_actuator.go
@@ -1097,7 +1097,7 @@ func getFootlooseMachineIP(uri string) (string, error) {
 func invokeFootlooseCreate(machine *clusterv1.Machine) (string, error) {
 	params := map[string]interface{}{
 		"name":       machine.Name,
-		"image":      "quay.io/footloose/centos7:0.6.1",
+		"image":      "quay.io/footloose/centos7:0.6.3",
 		"privileged": true,
 		"backend":    footlooseBackend,
 	}

--- a/test/container/images/centos7/Dockerfile
+++ b/test/container/images/centos7/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/footloose/centos7:0.3.0
+FROM quay.io/footloose/centos7:0.6.3
 
 RUN yum -y install sudo kubernetes-client
 

--- a/test/container/images/names.go
+++ b/test/container/images/names.go
@@ -2,5 +2,5 @@ package images
 
 const (
 	CentOS7    = "quay.io/wksctl/centos7"
-	Ubuntu1804 = "quay.io/footloose/ubuntu18.04:0.4.0"
+	Ubuntu1804 = "quay.io/footloose/ubuntu18.04:0.6.3"
 )


### PR DESCRIPTION
- Updated image ensures that the combination of machine id and uuid is unique otherwise the logic to return cluster nodes will fail