### PR TITLE
Update default version of k8s to 1.16.11

### DIFF
--- a/environments/local-docker-registry/retag_push.sh
+++ b/environments/local-docker-registry/retag_push.sh
@@ -16,13 +16,13 @@ set -e
 
 # Images currently used by WKS:
 IMAGES=(
-k8s.gcr.io/kube-apiserver:v1.14.1
-k8s.gcr.io/kube-controller-manager:v1.14.1
-k8s.gcr.io/kube-scheduler:v1.14.1
-k8s.gcr.io/kube-proxy:v1.14.1
+k8s.gcr.io/kube-apiserver:v1.16.11
+k8s.gcr.io/kube-controller-manager:v1.16.11
+k8s.gcr.io/kube-scheduler:v1.16.11
+k8s.gcr.io/kube-proxy:v1.16.11
 k8s.gcr.io/pause:3.1
-k8s.gcr.io/etcd:3.3.10
-k8s.gcr.io/coredns:1.3.1
+k8s.gcr.io/etcd:3.3.15-0
+k8s.gcr.io/coredns:1.6.2
 docker.io/weaveworks/weave-npc:2.5.1
 docker.io/weaveworks/weave-kube:2.5.1
 )

--- a/pkg/kubernetes/version.go
+++ b/pkg/kubernetes/version.go
@@ -1,7 +1,7 @@
 package kubernetes
 
 // DefaultVersion is the default Kubernetes version used by WKS.
-const DefaultVersion = "1.14.1"
+const DefaultVersion = "1.16.11"
 
 // DefaultVersionsRange is the default Kubernetes versions' range used by WKS to validate Kubernetes versions.
 const DefaultVersionsRange = ">=1.14.1 <=1.17.5"

--- a/pkg/plan/resource/kubectl_wait.go
+++ b/pkg/plan/resource/kubectl_wait.go
@@ -2,6 +2,7 @@ package resource
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -64,7 +65,7 @@ func kubectlWait(r plan.Runner, args kubectlWaitArgs) error {
 	for {
 		cmd := fmt.Sprintf("kubectl get %q %s%s", args.WaitType, waitOn(args), waitNamespace(args))
 		output, err := r.RunCommand(withoutProxy(cmd), nil)
-		if err != nil || output == "No resources found.\n" {
+		if err != nil || strings.Contains(output, "No resources found") {
 			time.Sleep(500 * time.Millisecond)
 		} else {
 			break

--- a/test/integration/test/apply_test.go
+++ b/test/integration/test/apply_test.go
@@ -528,7 +528,7 @@ func TestApply(t *testing.T) {
 
 	//Test we have installed the specified version.
 	t.Run("KubernetesVersion", func(t *testing.T) {
-		testApplyKubernetesVersion(t, "1.14.1")
+		testApplyKubernetesVersion(t, "1.16.11")
 	})
 
 	// Test we can run kubectl against the cluster.


### PR DESCRIPTION
Prompted by github.com/kubernetes/kubernetes/issues/92242 - issues in yum and deb packages causing install failures.

This changes the default, and the version used in CI tests, but you can still request any version back to 1.14.

This is very similar to #226, but done by cherry-picking the change a95e08408c98f already made on `release-0.8` 