### PR TITLE
Add golangci-lint linting using Github Actions and fix errors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,6 @@ jobs:
       - checkout
       - setup_remote_docker
       - run: make
-      - run: make lint
       - run:
           name: Check that generated files haven't been changed since checkout
           command: |

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -10,4 +10,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v1
         with:
-          version: v1.26
+          version: v1.27

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -1,0 +1,13 @@
+# https://github.com/marketplace/actions/run-golangci-lint
+name: golangci-lint
+on: [push, pull_request]
+jobs:
+  golangci:
+    name: linter
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v1
+        with:
+          version: v1.26

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 /test/resource/tests
 /test/integration/test/kubectl
 
-# Ignore generated binaries
+# Ignore generated binaries:
 /cmd/controller/controller
 /cmd/mock-authz-server/server
 /cmd/mock-https-authz-server/server
@@ -29,5 +29,5 @@ terraform.tfstate.backup
 .terraform.tfstate.lock.info
 tf.json
 
-# Docs
+# Docs:
 site

--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ install: cmd/wksctl/wksctl
 	cp cmd/wksctl/wksctl $(WKSCTL_INSTALL_PATH)
 
 lint:
-	@bin/go-lint
+	@tools/go-lint
 
 clean:
 	$(SUDO) docker rmi $(IMAGE_NAMES) >/dev/null 2>&1 || true

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -16,7 +16,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
-	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
+	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 )
 
 var options struct {

--- a/cmd/mock-authz-server/main.go
+++ b/cmd/mock-authz-server/main.go
@@ -27,8 +27,14 @@ func authHandler(w http.ResponseWriter, r *http.Request) {
 		sar.Status.Allowed = true
 	}
 
+	err = json.NewEncoder(w).Encode(sar)
+	if err != nil {
+		log.Println("[Error]", err.Error())
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
 	w.WriteHeader(http.StatusOK)
-	json.NewEncoder(w).Encode(sar)
 }
 
 func main() {

--- a/cmd/mock-https-authz-server/main.go
+++ b/cmd/mock-https-authz-server/main.go
@@ -32,8 +32,14 @@ func authorizeHandler(w http.ResponseWriter, r *http.Request) {
 		sar.Status.Allowed = true
 	}
 
+	err = json.NewEncoder(w).Encode(sar)
+	if err != nil {
+		log.Println("[Error]", err.Error())
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
 	w.WriteHeader(http.StatusOK)
-	json.NewEncoder(w).Encode(sar)
 }
 
 func authenticateHandler(w http.ResponseWriter, r *http.Request) {

--- a/cmd/wksctl/addon/build/build.go
+++ b/cmd/wksctl/addon/build/build.go
@@ -74,7 +74,9 @@ func addonBuildRun(cmd *cobra.Command, args []string) {
 	}
 
 	if opts.outputDirectory != "" {
-		os.MkdirAll(opts.outputDirectory, 0770)
+		if err = os.MkdirAll(opts.outputDirectory, 0770); err != nil {
+			log.Fatal(err)
+		}
 	}
 
 	addonOptions := addons.BuildOptions{

--- a/cmd/wksctl/apply/apply.go
+++ b/cmd/wksctl/apply/apply.go
@@ -61,7 +61,7 @@ func init() {
 
 	// Hide controller-image flag as it is a helper/debug flag.
 	Cmd.Flags().StringVar(&globalParams.controllerImage, "controller-image", "", "Controller image override")
-	Cmd.Flags().MarkHidden("controller-image")
+	_ = Cmd.Flags().MarkHidden("controller-image")
 }
 
 type Applier struct {

--- a/cmd/wksctl/bashcompletions/bashcompletions.go
+++ b/cmd/wksctl/bashcompletions/bashcompletions.go
@@ -28,9 +28,13 @@ and follow instructions for your OS to configure/install the completion file.
 			if err != nil {
 				log.Fatal(err)
 			}
-			cmd.Root().GenBashCompletion(outfile)
+			if err = cmd.Root().GenBashCompletion(outfile); err != nil {
+				log.Fatal(err)
+			}
 		} else {
-			cmd.Root().GenBashCompletion(os.Stdout)
+			if err := cmd.Root().GenBashCompletion(os.Stdout); err != nil {
+				log.Fatal(err)
+			}
 		}
 	}}
 

--- a/cmd/wksctl/init/init.go
+++ b/cmd/wksctl/init/init.go
@@ -98,7 +98,7 @@ func init() {
 	Cmd.Flags().StringVar(&initOptions.machinesManifestPath, "machines", "machines.yaml", "Location of machines manifest")
 	Cmd.Flags().StringVar(
 		&initOptions.dependencyPath, "dependency-file", "./dependencies.toml", "path to file containing version information for all dependencies")
-	Cmd.MarkPersistentFlagRequired("git-url")
+	_ = Cmd.MarkPersistentFlagRequired("git-url")
 }
 
 // selectors
@@ -206,7 +206,9 @@ func updateManifests(options initOptionType) error {
 					if err != nil {
 						return err
 					}
-					ioutil.WriteFile(path, newContents, info.Mode())
+					if err := ioutil.WriteFile(path, newContents, info.Mode()); err != nil {
+						return err
+					}
 					// Don't break; if multiple files "match", make sure we update all of them
 				}
 			}

--- a/cmd/wksctl/kubeconfig/kubeconfig.go
+++ b/cmd/wksctl/kubeconfig/kubeconfig.go
@@ -64,7 +64,7 @@ func init() {
 	Cmd.Flags().BoolVar(
 		&kubeconfigOptions.skipTLSVerify, "insecure-skip-tls-verify", false,
 		"Enables kubectl to communicate with the API w/o verifying the certificate")
-	Cmd.Flags().MarkHidden("insecure-skip-tls-verify")
+	_ = Cmd.Flags().MarkHidden("insecure-skip-tls-verify")
 
 	// Intentionally shadows the globally defined --verbose flag.
 	Cmd.Flags().BoolVarP(&kubeconfigOptions.verbose, "verbose", "v", false, "Enable verbose output")

--- a/cmd/wksctl/main.go
+++ b/cmd/wksctl/main.go
@@ -45,8 +45,12 @@ func configureLogger(cmd *cobra.Command, args []string) {
 }
 
 func main() {
-	clusterv1.AddToScheme(scheme.Scheme)
-	baremetalv1.AddToScheme(scheme.Scheme)
+	if err := clusterv1.AddToScheme(scheme.Scheme); err != nil {
+		log.Fatal(err)
+	}
+	if err := baremetalv1.AddToScheme(scheme.Scheme); err != nil {
+		log.Fatal(err)
+	}
 
 	rootCmd.PersistentFlags().BoolVarP(&options.verbose, "verbose", "v", false, "Enable verbose output")
 

--- a/cmd/wksctl/registrysynccommands/registrysynccommands.go
+++ b/cmd/wksctl/registrysynccommands/registrysynccommands.go
@@ -7,10 +7,8 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/weaveworks/wksctl/pkg/addons"
-	"github.com/weaveworks/wksctl/pkg/cluster/machine"
 	"github.com/weaveworks/wksctl/pkg/kubernetes"
 	"github.com/weaveworks/wksctl/pkg/registry"
-	v "github.com/weaveworks/wksctl/pkg/utilities/version"
 )
 
 var Cmd = &cobra.Command{
@@ -70,18 +68,4 @@ func registrySyncRun(cmd *cobra.Command, args []string) {
 	for _, command := range commands {
 		fmt.Println(command)
 	}
-}
-
-func kubernetesVersionsRange() string {
-	if registrySyncOptions.machinesManifestPath != "" {
-		version, _, err := machine.GetKubernetesVersionFromManifest(registrySyncOptions.machinesManifestPath)
-		if err != nil {
-			log.Fatalf("Failed to extract Kubernetes version from machines manifest: %s", err)
-		}
-		return fmt.Sprintf("=%s", version)
-	}
-	if registrySyncOptions.versionsRange != "" {
-		return registrySyncOptions.versionsRange
-	}
-	return v.AnyRange
 }

--- a/cmd/wksctl/zshcompletions/zshcompletions.go
+++ b/cmd/wksctl/zshcompletions/zshcompletions.go
@@ -28,9 +28,13 @@ and follow instructions for your OS to configure/install the completion file.
 			if err != nil {
 				log.Fatal(err)
 			}
-			cmd.Root().GenZshCompletion(outfile)
+			if err = cmd.Root().GenZshCompletion(outfile); err != nil {
+				log.Fatal(err)
+			}
 		} else {
-			cmd.Root().GenZshCompletion(os.Stdout)
+			if err := cmd.Root().GenZshCompletion(os.Stdout); err != nil {
+				log.Fatal(err)
+			}
 		}
 	}}
 

--- a/go.sum
+++ b/go.sum
@@ -892,6 +892,7 @@ k8s.io/apiextensions-apiserver v0.17.2 h1:cP579D2hSZNuO/rZj9XFRzwJNYb41DbNANJb6K
 k8s.io/apiextensions-apiserver v0.17.2/go.mod h1:4KdMpjkEjjDI2pPfBA15OscyNldHWdBCfsWMDWAmSTs=
 k8s.io/apimachinery v0.17.2 h1:hwDQQFbdRlpnnsR64Asdi55GyCaIP/3WQpMmbNBeWr4=
 k8s.io/apimachinery v0.17.2/go.mod h1:b9qmWdKlLuU9EBh+06BtLcSf/Mu89rWL33naRxs1uZg=
+k8s.io/apiserver v0.17.2 h1:NssVvPALll6SSeNgo1Wk1h2myU1UHNwmhxV0Oxbcl8Y=
 k8s.io/apiserver v0.17.2/go.mod h1:lBmw/TtQdtxvrTk0e2cgtOxHizXI+d0mmGQURIHQZlo=
 k8s.io/cli-runtime v0.17.2/go.mod h1:aa8t9ziyQdbkuizkNLAw3qe3srSyWh9zlSB7zTqRNPI=
 k8s.io/client-go v0.17.2 h1:ndIfkfXEGrNhLIgkr0+qhRguSD3u6DCmonepn1O6NYc=
@@ -946,7 +947,6 @@ mvdan.cc/unparam v0.0.0-20190209190245-fbb59629db34/go.mod h1:H6SUd1XjIs+qQCyskX
 rsc.io/pdf v0.1.1/go.mod h1:n8OzWcQ6Sp37PL01nO98y4iUCRdTGarVfzxY20ICaU4=
 sigs.k8s.io/cluster-api v0.3.3 h1:pNuvC6cm67SbxOaPriK8ZfLl1RSjmu/KX2GJiNQH3dU=
 sigs.k8s.io/cluster-api v0.3.3/go.mod h1:lgztyeCWCve8YB4DN6QeLR0blNYBvFX9+ATHrxs+zKU=
-sigs.k8s.io/cluster-api v0.3.6 h1:Md//qVTwPvJFIBzQ8Mnsro1510x4UFtOyx4t6sPoDnM=
 sigs.k8s.io/controller-runtime v0.5.2 h1:pyXbUfoTo+HA3jeIfr0vgi+1WtmNh0CwlcnQGLXwsSw=
 sigs.k8s.io/controller-runtime v0.5.2/go.mod h1:JZUwSMVbxDupo0lTJSSFP5pimEyxGynROImSsqIOx1A=
 sigs.k8s.io/kind v0.7.1-0.20200303021537-981bd80d3802/go.mod h1:HIZ3PWUezpklcjkqpFbnYOqaqsAE1JeCTEwkgvPLXjk=

--- a/pkg/addons/addon.go
+++ b/pkg/addons/addon.go
@@ -9,7 +9,6 @@ import (
 	"path"
 	"path/filepath"
 	"sort"
-	"sync"
 
 	"github.com/ghodss/yaml"
 	"github.com/google/go-jsonnet"
@@ -19,8 +18,6 @@ import (
 	"github.com/weaveworks/wksctl/pkg/registry"
 	"github.com/weaveworks/wksctl/pkg/utilities/manifest"
 )
-
-var mutex *sync.Mutex = &sync.Mutex{}
 
 const (
 	descriptor = "addon.json"

--- a/pkg/addons/addon_test.go
+++ b/pkg/addons/addon_test.go
@@ -46,9 +46,10 @@ func TestBuildAllAddons(t *testing.T) {
 
 	for _, addon := range List() {
 		t.Run(addon.ShortName, func(t *testing.T) {
-			addon.autoBuild(BuildOptions{
+			_, err = addon.autoBuild(BuildOptions{
 				OutputDirectory: dir,
 			})
+			assert.NoError(t, err)
 		})
 	}
 }

--- a/pkg/addons/image_reference_regexp.go
+++ b/pkg/addons/image_reference_regexp.go
@@ -39,16 +39,8 @@ var (
 	// TagRegexp matches valid tag names. From docker/docker:graph/tags.go.
 	TagRegexp = match(`[\w][\w.-]{0,127}`)
 
-	// anchoredTagRegexp matches valid tag names, anchored at the start and
-	// end of the matched string.
-	anchoredTagRegexp = anchored(TagRegexp)
-
 	// DigestRegexp matches valid digests.
 	DigestRegexp = match(`[A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*[:][[:xdigit:]]{32,}`)
-
-	// anchoredDigestRegexp matches valid digests, anchored at the start and
-	// end of the matched string.
-	anchoredDigestRegexp = anchored(DigestRegexp)
 
 	// NameRegexp is the format for the name component of references. The
 	// regexp has capturing groups for the domain and name part omitting

--- a/pkg/addons/transform.go
+++ b/pkg/addons/transform.go
@@ -7,14 +7,6 @@ import (
 
 type transform func(object) object
 
-func printObject(o object) {
-	json, err := o.toJSON()
-	if err != nil {
-		fmt.Println(err)
-	}
-	fmt.Println(string(json))
-}
-
 func list(items []object) object {
 	return object{
 		"apiVersion": "v1",

--- a/pkg/apis/wksprovider/controller/wksctl/machine_controller.go
+++ b/pkg/apis/wksprovider/controller/wksctl/machine_controller.go
@@ -825,6 +825,8 @@ func (a *MachineController) setNodeLabel(node *corev1.Node, label, value string)
 	return nil
 }
 
+//nolint:unused
+// TODO: Remove if really unused
 func (a *MachineController) removeNodeLabel(node *corev1.Node, label string) error {
 	err := a.modifyNode(node, func(node *corev1.Node) {
 		delete(node.Labels, label)
@@ -909,8 +911,12 @@ func (a *MachineController) findNodeByID(machineID, systemUUID string) (*corev1.
 	return nil, apierrs.NewNotFound(schema.GroupResource{Group: "", Resource: "nodes"}, "")
 }
 
+//nolint:unused
+// TODO: Needed for getMasterNode()
 var staticRand = rand.New(rand.NewSource(time.Now().Unix()))
 
+//nolint:unused
+// TODO: Remove if really unused
 func (a *MachineController) getMasterNode() (*corev1.Node, error) {
 	masters, err := a.getMasterNodes()
 	if err != nil {
@@ -977,6 +983,8 @@ func (a *MachineController) getControllerNodeName() (string, error) {
 	return "", err
 }
 
+//nolint:unused
+// TODO: Remove if really unused
 func (a *MachineController) updateMachine(machine *baremetalspecv1.BareMetalMachine, ip string) {
 	machineIPs[getMachineID(machine)] = ip
 }

--- a/pkg/apis/wksprovider/controller/wksctl/machine_controller.go
+++ b/pkg/apis/wksprovider/controller/wksctl/machine_controller.go
@@ -1,19 +1,13 @@
 package wks
 
 import (
-	"bytes"
 	"context"
 	"encoding/base64"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"math/rand"
-	"net/http"
-	"net/url"
 	goos "os"
-	"path/filepath"
-	"regexp"
 	"time"
 
 	"github.com/chanwit/plandiff"
@@ -59,14 +53,12 @@ const (
 	controllerName      string = "wks-controller"
 	controllerSecret    string = "wks-controller-secrets"
 	bootstrapTokenID    string = "bootstrapTokenID"
-	clusterName         string = "wks-firekube"
 )
 
 var (
 	footlooseAddr    = "<unknown>"
 	footlooseBackend = "docker"
 	machineIPs       = map[string]string{}
-	hostAddrRegexp   = regexp.MustCompile(`(?m)controlPlaneEndpoint[:]\s*([^:\s]+)`)
 )
 
 // STOPGAP: copy of machine def from footloose; the footloose version has private fields
@@ -175,15 +167,11 @@ func (r *MachineController) Reconcile(req ctrl.Request) (_ ctrl.Result, reterr e
 		return ctrl.Result{}, err
 	}
 
-	{
-		err := r.update(ctx, bmc, machine, bmm)
-		if err != nil {
-			contextLog.Errorf("failed to update machine: %v", err)
-		}
-		return ctrl.Result{}, err
+	err = r.update(ctx, bmc, machine, bmm)
+	if err != nil {
+		contextLog.Errorf("failed to update machine: %v", err)
 	}
-
-	return ctrl.Result{}, nil
+	return ctrl.Result{}, err
 }
 
 func (a *MachineController) create(ctx context.Context, installer *os.OS, c *baremetalspecv1.BareMetalCluster, machine *clusterv1.Machine, bmm *baremetalspecv1.BareMetalMachine) error {
@@ -755,14 +743,6 @@ func (a *MachineController) isOriginalMaster(node *corev1.Node) (bool, error) {
 	return masterNode.Name == node.Name, nil
 }
 
-func extractEndpointAddress(urlstr string) (string, error) {
-	u, err := url.Parse(urlstr)
-	if err != nil {
-		return "", err
-	}
-	return u.Hostname(), nil
-}
-
 func machineVersion(machine *clusterv1.Machine) string {
 	return "v" + machineutil.GetKubernetesVersion(machine)
 }
@@ -987,72 +967,6 @@ func (a *MachineController) getControllerNodeName() (string, error) {
 // TODO: Remove if really unused
 func (a *MachineController) updateMachine(machine *baremetalspecv1.BareMetalMachine, ip string) {
 	machineIPs[getMachineID(machine)] = ip
-}
-
-func getMachineName(uri string) string {
-	return filepath.Base(uri)
-}
-
-func getFootlooseMachineIP(uri string) (string, error) {
-	machineName := getMachineName(uri)
-	req := &http.Request{
-		Method: "GET",
-		URL: &url.URL{
-			Opaque: fmt.Sprintf("/api/clusters/%s/machines/%s", clusterName, machineName),
-			Scheme: "http",
-			Host:   footlooseAddr,
-		},
-		Close: true,
-	}
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return "", fmt.Errorf("Error retrieving footloose machine: %v\n", err)
-	}
-	defer resp.Body.Close()
-	var m FootlooseMachine
-	if err := json.NewDecoder(resp.Body).Decode(&m); err != nil {
-		return "", err
-	}
-	nets := m.RuntimeNetworks
-	for _, net := range nets {
-		if net.Name == "bridge" {
-			return net.IP, nil
-		}
-	}
-	return "", fmt.Errorf("Could not find bridge network for machine: %s", machineName)
-}
-
-func invokeFootlooseCreate(machine *clusterv1.Machine) (string, error) {
-	params := map[string]interface{}{
-		"name":       machine.Name,
-		"image":      "quay.io/footloose/centos7:0.6.1",
-		"privileged": true,
-		"backend":    footlooseBackend,
-	}
-	postdata, err := json.Marshal(params)
-	if err != nil {
-		return "", err
-	}
-	resp, err := http.Post(fmt.Sprintf("http://%s/api/clusters/%s/machines", footlooseAddr, clusterName),
-		"application/json", bytes.NewReader(postdata))
-	if err != nil {
-		return "", fmt.Errorf("Error creating footloose machine: %v\n", err)
-	} else {
-		defer resp.Body.Close()
-	}
-	m := map[string]interface{}{}
-	if err := json.NewDecoder(resp.Body).Decode(&m); err != nil {
-		return "", err
-	}
-	uri, ok := m["uri"]
-	if !ok {
-		uri = []byte(fmt.Sprintf("http://%s/api/clusters/%s/machines/%s", footlooseAddr, clusterName, machine.Name))
-	}
-	ustr, ok := uri.(string)
-	if !ok {
-		return "", fmt.Errorf("Invalid uri for: %s", machine.Name)
-	}
-	return getFootlooseMachineIP(ustr)
 }
 
 func isMaster(node *corev1.Node) bool {

--- a/pkg/apis/wksprovider/machine/os/os.go
+++ b/pkg/apis/wksprovider/machine/os/os.go
@@ -1127,7 +1127,8 @@ func (params NodeParams) Validate() error {
 // SetupSeedNode was called.
 func (o OS) SetupNode(p *plan.Plan) error {
 	// We don't know the state of the machine so undo at the beginning
-	p.Undo(o.runner, plan.EmptyState)
+	//nolint:errcheck
+	p.Undo(o.runner, plan.EmptyState) // TODO: Implement error checking
 
 	_, err := p.Apply(o.runner, plan.EmptyDiff())
 	if err != nil {

--- a/pkg/apis/wksprovider/machine/os/os_test.go
+++ b/pkg/apis/wksprovider/machine/os/os_test.go
@@ -76,7 +76,7 @@ spec:
 			continue
 		}
 		d := &v1beta2.Deployment{}
-		yaml.Unmarshal(out, d)
+		assert.NoError(t, yaml.Unmarshal(out, d))
 		if len(d.Spec.Template.Spec.Containers) == 0 {
 			continue
 		}
@@ -96,8 +96,9 @@ func TestFlux(t *testing.T) {
 	dk := "the deploy key"
 	f, err := ioutil.TempFile("", "")
 	assert.NoError(t, err)
-	f.WriteString(dk)
-	f.Close()
+	_, err = f.WriteString(dk)
+	assert.NoError(t, f.Close())
+	assert.NoError(t, err)
 	var gitDeployKeyPath = f.Name()
 	var tests = []struct {
 		URL, branch, deployKeyPath, notExp, expManifestText, notExpManifestText, msg string
@@ -123,8 +124,9 @@ func TestFlux(t *testing.T) {
 		b.AddResource("kubectl:apply:cluster", applyClstrRsc)
 		applyMachinesRsc := &resource.KubectlApply{ManifestPath: object.String("")}
 		b.AddResource("kubectl:apply:machines", applyMachinesRsc)
-		o.configureFlux(b, SeedNodeParams{GitData: GitParams{GitURL: test.URL, GitBranch: test.branch, GitDeployKeyPath: test.deployKeyPath},
+		err = o.configureFlux(b, SeedNodeParams{GitData: GitParams{GitURL: test.URL, GitBranch: test.branch, GitDeployKeyPath: test.deployKeyPath},
 			Namespace: "system"})
+		assert.NoError(t, err)
 		p, err := b.Plan()
 		assert.NoError(t, err)
 		rjson := p.ToJSON()

--- a/pkg/baremetal/v1alpha3/register.go
+++ b/pkg/baremetal/v1alpha3/register.go
@@ -6,12 +6,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-// +k8s:deepcopy-gen=false
-type BareMetalProviderSpecCodec struct {
-	encoder runtime.Encoder
-	decoder runtime.Decoder
-}
-
 const GroupName = "cluster.weave.works"
 
 var SchemeGroupVersion = schema.GroupVersion{Group: GroupName, Version: "v1alpha3"}

--- a/pkg/cluster/machine/machine.go
+++ b/pkg/cluster/machine/machine.go
@@ -90,8 +90,6 @@ func Parse(r io.ReadCloser) (ml []*clusterv1.Machine, bl []*baremetalspecv1.Bare
 	return ml, bl, nil
 }
 
-type machineValidationFunc func(int, *clusterv1.Machine) field.ErrorList
-
 // Validate validates the provided machines.
 func Validate(machines []*clusterv1.Machine, bl []*baremetalspecv1.BareMetalMachine) field.ErrorList {
 	if len(machines) == 0 { // Some other validations crash on empty list

--- a/pkg/cluster/machine/machine.go
+++ b/pkg/cluster/machine/machine.go
@@ -173,7 +173,7 @@ func validateVersions(machines []*clusterv1.Machine) field.ErrorList {
 				errors = append(errors, field.Invalid(
 					machinePath(i, "spec", "version"),
 					m.Spec.Version,
-					fmt.Sprintf("inconsistent kubernetes version, expected nil")))
+					"inconsistent kubernetes version, expected nil"))
 			}
 		} else {
 			if m.Spec.Version == nil {

--- a/pkg/cluster/machine/machines_manifest.go
+++ b/pkg/cluster/machine/machines_manifest.go
@@ -62,7 +62,10 @@ func WriteMachines(w io.Writer, machines []*clusterv1.Machine, bml []*baremetals
 		if err != nil {
 			return err
 		}
-		w.Write([]byte("---\n"))
+		_, err = w.Write([]byte("---\n"))
+		if err != nil {
+			return err
+		}
 		_, err = w.Write(manifestBytes)
 		if err != nil {
 			return err
@@ -73,7 +76,10 @@ func WriteMachines(w io.Writer, machines []*clusterv1.Machine, bml []*baremetals
 		if err != nil {
 			return err
 		}
-		w.Write([]byte("---\n"))
+		_, err = w.Write([]byte("---\n"))
+		if err != nil {
+			return err
+		}
 		_, err = w.Write(manifestBytes)
 		if err != nil {
 			return err

--- a/pkg/cluster/machine/machines_manifest_test.go
+++ b/pkg/cluster/machine/machines_manifest_test.go
@@ -43,7 +43,7 @@ func TestUpdateWithGeneratedNamesWithGenerateNameFieldsShouldGenerateThese(t *te
 	assert.Contains(t, updatedManifest, "name:")
 	for _, line := range strings.Split(updatedManifest, "\n") {
 		if strings.HasPrefix(strings.TrimSpace(line), "name:") {
-			assert.Regexp(t, regexp.MustCompile("^\\s+name: (master|node)-[0-9A-Za-z]{5}-[0-9A-Za-z]{5}$"), line)
+			assert.Regexp(t, regexp.MustCompile(`^\s+name: (master|node)-[0-9A-Za-z]{5}-[0-9A-Za-z]{5}$`), line)
 		}
 	}
 	fmt.Print(updatedManifest)
@@ -87,9 +87,9 @@ func TestUpdateWithGeneratedNamesWithCustomNameAndGenerateNameFieldsShouldOnlyCh
 	assert.Contains(t, updatedManifest, "name: very-custom-worker-node")
 	for _, line := range strings.Split(updatedManifest, "\n") {
 		if strings.HasPrefix(strings.TrimSpace(line), "name: master-") {
-			assert.Regexp(t, regexp.MustCompile("^\\s+name: master-[0-9A-Za-z]{5}-[0-9A-Za-z]{5}$"), line)
+			assert.Regexp(t, regexp.MustCompile(`^\s+name: master-[0-9A-Za-z]{5}-[0-9A-Za-z]{5}$`), line)
 		} else if strings.HasPrefix(strings.TrimSpace(line), "name: node-") {
-			assert.Regexp(t, regexp.MustCompile("^\\s+name: node-[0-9A-Za-z]{5}-[0-9A-Za-z]{5}$"), line)
+			assert.Regexp(t, regexp.MustCompile(`^\s+name: node-[0-9A-Za-z]{5}-[0-9A-Za-z]{5}$`), line)
 		}
 	}
 	r = ioutil.NopCloser(strings.NewReader(updatedManifest))

--- a/pkg/kubernetes/config/kubeconfig_test.go
+++ b/pkg/kubernetes/config/kubeconfig_test.go
@@ -121,9 +121,10 @@ func TestInvalidExistingConfig(t *testing.T) {
 	testDataDir := "./testdata/"
 	testDataPath := "./testdata/test_kubeconfig"
 	defer os.RemoveAll(testDataDir)
-	os.Mkdir(testDataDir, 0777)
+	err := os.Mkdir(testDataDir, 0777)
+	assert.NoError(t, err)
 
-	err := ioutil.WriteFile(testDataPath, []byte(invalidConfigWithSSHBanner), 0777)
+	err = ioutil.WriteFile(testDataPath, []byte(invalidConfigWithSSHBanner), 0777)
 	assert.NoError(t, err)
 
 	validConfig, err := clientcmd.Load([]byte(validConfig))

--- a/pkg/kubernetes/config/kubeconfig_test.go
+++ b/pkg/kubernetes/config/kubeconfig_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/weaveworks/wksctl/pkg/kubernetes/config"
 	clientcmd "k8s.io/client-go/tools/clientcmd"
 )
@@ -122,7 +123,7 @@ func TestInvalidExistingConfig(t *testing.T) {
 	testDataPath := "./testdata/test_kubeconfig"
 	defer os.RemoveAll(testDataDir)
 	err := os.Mkdir(testDataDir, 0777)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = ioutil.WriteFile(testDataPath, []byte(invalidConfigWithSSHBanner), 0777)
 	assert.NoError(t, err)

--- a/pkg/kubernetes/drain/facade.go
+++ b/pkg/kubernetes/drain/facade.go
@@ -138,7 +138,7 @@ func evictPodsOn(node *corev1.Node, drainer *Helper) (int, error) {
 }
 
 func wait(timeOut time.Duration, start time.Time) {
-	elapsed := time.Now().Sub(start)
+	elapsed := time.Since(start)
 	remainingTime := timeOut - elapsed
 	time.Sleep(min(remainingTime, max(5*time.Second, timeOut/10)))
 }

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -34,8 +34,9 @@ func TestSSHDeployKey(t *testing.T) {
 		Type:  "RSA PRIVATE KEY",
 		Bytes: x509.MarshalPKCS1PrivateKey(pk),
 	})
-	f.Write(keyPem)
-	f.Close()
+	_, err = f.Write(keyPem)
+	assert.NoError(t, f.Close())
+	assert.NoError(t, err)
 	co, err := cloneOptions("url", f.Name(), "")
 	assert.NoError(t, err)
 	assert.NotNil(t, co.Auth)

--- a/pkg/plan/graph.go
+++ b/pkg/plan/graph.go
@@ -46,15 +46,6 @@ func (g *graph) AddNodes(names ...string) bool {
 	return updated
 }
 
-func containsEdge(edges []edge, edge edge) bool {
-	for _, e := range edges {
-		if e == edge {
-			return true
-		}
-	}
-	return false
-}
-
 func (g *graph) AddEdge(from, to string) bool {
 	edgesFrom := g.edges[from]
 	if edgesFrom == nil {

--- a/pkg/plan/graph.go
+++ b/pkg/plan/graph.go
@@ -5,11 +5,6 @@ package plan
 //   Copyright 2017 Hirotomo Moriwaki
 //   MIT licensed.
 
-// Added to support comparing graphs for equality
-type edge struct {
-	from, to string
-}
-
 type graph struct {
 	nodes   map[string]bool
 	edges   map[string]map[string]bool

--- a/pkg/plan/recipe/install_plans.go
+++ b/pkg/plan/recipe/install_plans.go
@@ -169,11 +169,6 @@ func BuildCRIPlan(criSpec *baremetalspecv1.ContainerRuntime, cfg *envcfg.EnvSpec
 	return &p
 }
 
-var swapContents = `[Service]
-# Disable swap to please kubeadm. See: https://github.com/kubernetes/kubeadm/issues/610
-ExecStartPre=-/sbin/swapoff -a
-`
-
 // BuildK8SPlan creates a plan for running kubernetes on a node
 func BuildK8SPlan(kubernetesVersion string, kubeletNodeIP string, seLinuxInstalled, setSELinuxPermissive, disableSwap, lockYUMPkgs bool, pkgType resource.PkgType, cloudProvider string, extraArgs map[string]string) plan.Resource {
 	b := plan.NewBuilder()

--- a/pkg/plan/resource/file.go
+++ b/pkg/plan/resource/file.go
@@ -70,7 +70,7 @@ func checksumFromFile(path string) ([]byte, error) {
 
 func checksumFromString(content string) []byte {
 	h := md5.New()
-	io.WriteString(h, content)
+	_, _ = io.WriteString(h, content)
 	return h.Sum(nil)
 }
 

--- a/pkg/plan/resource/kubeadm_init.go
+++ b/pkg/plan/resource/kubeadm_init.go
@@ -255,7 +255,7 @@ func buildKubeadmInitPlan(path string, ignorePreflightErrors string, useIPTables
 
 	// If we're at 1.17.0 or greater, we need to upgrade the kubeadm config before running "kubeadm init"
 	upgradeKubeadmConfig := false
-	if lt, err := version.LessThan(k8sVersion, "1.17.0"); err == nil && lt == false {
+	if lt, err := version.LessThan(k8sVersion, "1.17.0"); err == nil && !lt {
 		upgradeKubeadmConfig = true
 	}
 

--- a/pkg/plan/resource/kubeadm_init.go
+++ b/pkg/plan/resource/kubeadm_init.go
@@ -129,7 +129,8 @@ func (ki *KubeadmInit) Apply(runner plan.Runner, diff plan.Diff) (bool, error) {
 		return false, errors.Wrap(err, "failed to upload kubeadm's configuration")
 	}
 	log.WithField("yaml", string(config)).Debug("uploaded kubeadm's configuration")
-	defer removeFile(remotePath, runner)
+	//nolint:errcheck
+	defer removeFile(remotePath, runner) // TODO: Deferred error checking
 
 	var stdOutErr string
 	p := buildKubeadmInitPlan(

--- a/pkg/plan/resource/kubectl_apply.go
+++ b/pkg/plan/resource/kubectl_apply.go
@@ -169,7 +169,7 @@ func kubectlRemoteApply(remoteURL string, runner plan.Runner) error {
 	cmd := fmt.Sprintf("kubectl apply -f %q", remoteURL)
 
 	if stdouterr, err := runner.RunCommand(withoutProxy(cmd), nil); err != nil {
-		log.WithField("stdouterr", stdouterr).WithField("URL", remoteURL).Debug(fmt.Sprintf("failed to apply Kubernetes manifest"))
+		log.WithField("stdouterr", stdouterr).WithField("URL", remoteURL).Debug("failed to apply Kubernetes manifest")
 		return errors.Wrapf(err, "failed to apply manifest %s; output %s", remoteURL, stdouterr)
 	}
 	return nil

--- a/pkg/plan/resource/kubectl_apply.go
+++ b/pkg/plan/resource/kubectl_apply.go
@@ -146,7 +146,8 @@ func kubectlApply(r plan.Runner, args kubectlApplyArgs, fname string) error {
 	if err != nil {
 		return errors.Wrap(err, "writeTempFile")
 	}
-	defer r.RunCommand(fmt.Sprintf("rm -vf %q", path), nil)
+	//nolint:errcheck
+	defer r.RunCommand(fmt.Sprintf("rm -vf %q", path), nil) // TODO: Deferred error checking
 
 	// Run kubectl apply.
 	if err := kubectlRemoteApply(path, r); err != nil {

--- a/pkg/plan/resource/os.go
+++ b/pkg/plan/resource/os.go
@@ -25,8 +25,7 @@ type OS struct {
 	MachineID  string `structs:"MachineID"`
 	SystemUUID string `structs:"SystemUUID"`
 
-	runner        plan.Runner
-	factsGathered bool
+	runner plan.Runner
 }
 
 type SELinuxStatus int

--- a/pkg/plan/resource/rpm.go
+++ b/pkg/plan/resource/rpm.go
@@ -109,10 +109,7 @@ func (p *RPM) stateDifferent(current plan.State) bool {
 
 	desired := p.label()
 	installed := label(current.String("name"), current.String("version"), current.String("release"))
-	if strings.HasPrefix(installed, desired) {
-		return false
-	}
-	return true
+	return !strings.HasPrefix(installed, desired)
 }
 
 // WouldChangeState returns false if a call to Apply() is guaranteed not to change the installed version of the package, and true otherwise.
@@ -148,11 +145,8 @@ func (p *RPM) Apply(r plan.Runner, diff plan.Diff) (bool, error) {
 }
 
 func (p *RPM) shouldUndo(current plan.State) bool {
-	if current.IsEmpty() {
-		// Package isn't installed, nothing to do!
-		return false
-	}
-	return true
+	// If package isn't installed, nothing to do!
+	return !current.IsEmpty()
 }
 
 // Undo implements plan.Resource

--- a/pkg/plan/resource/service.go
+++ b/pkg/plan/resource/service.go
@@ -102,7 +102,7 @@ func (p *Service) Apply(r plan.Runner, diff plan.Diff) (bool, error) {
 
 // Undo implements plan.Resource
 func (p *Service) Undo(r plan.Runner, current plan.State) error {
-	if current.Bool("enabled") == true {
+	if current.Bool("enabled") {
 		output, err := systemd(r, "disable %s", p.Name)
 		if err != nil {
 			if strings.Contains(output, "not loaded") {

--- a/pkg/specs/validation.go
+++ b/pkg/specs/validation.go
@@ -3,9 +3,7 @@ package specs
 import (
 	"fmt"
 	"net"
-	"os"
 	"path/filepath"
-	"time"
 
 	"github.com/weaveworks/launcher/pkg/kubectl"
 	"github.com/weaveworks/wksctl/pkg/addons"
@@ -119,11 +117,6 @@ func validateServiceDomain(cluster *clusterv1.Cluster, _ *baremetalspecv1.BareMe
 	return field.ErrorList{}
 }
 
-func fileExists(s string) bool {
-	_, err := os.Stat(s)
-	return err == nil
-}
-
 func validateSSHKeyEmpty(_ *clusterv1.Cluster, spec *baremetalspecv1.BareMetalClusterSpec, manifestPath string) field.ErrorList {
 	if spec.DeprecatedSSHKeyPath != "" {
 		return field.ErrorList{
@@ -135,11 +128,6 @@ func validateSSHKeyEmpty(_ *clusterv1.Cluster, spec *baremetalspecv1.BareMetalCl
 	}
 
 	return field.ErrorList{}
-}
-
-func isDuration(s string) bool {
-	_, err := time.ParseDuration(s)
-	return err == nil
 }
 
 func addonPath(i int, args ...string) *field.Path {

--- a/pkg/specs/validation_test.go
+++ b/pkg/specs/validation_test.go
@@ -120,6 +120,7 @@ spec:
   user: "vagrant"
 `
 
+//nolint:unused
 const ClusterAuthenticationBadCacheTTL = `items:
 apiVersion: "cluster.x-k8s.io/v1alpha3"
 kind: Cluster
@@ -144,6 +145,7 @@ spec:
       url: http://127.0.0.1:5000/authenticate
 `
 
+//nolint:unused
 const ClusterAuthenticationBadServerURL = `items:
 apiVersion: "cluster.x-k8s.io/v1alpha3"
 kind: Cluster
@@ -168,6 +170,7 @@ spec:
 	  url: file:///127.0.0.1:5000/authenticate
 `
 
+//nolint:unused
 const ClusterAuthenticationNoClientCert = `items:
 apiVersion: "cluster.x-k8s.io/v1alpha3"
 kind: Cluster
@@ -195,6 +198,7 @@ spec:
 	  certificateAuthorityData: SGVsbG8sIFdvcmxkIQo=
 `
 
+//nolint:unused
 const ClusterAuthorizationNoServerCert = `items:
 apiVersion: "cluster.x-k8s.io/v1alpha3"
 kind: Cluster
@@ -245,6 +249,7 @@ spec:
   - name: foo
 `
 
+//nolint:unused
 const ClusterAddonBadParameters = `
 apiVersion: "cluster.x-k8s.io/v1alpha3"
 kind: Cluster

--- a/pkg/utilities/manifest/manifest.go
+++ b/pkg/utilities/manifest/manifest.go
@@ -116,16 +116,19 @@ func updateNamespace(obj *runtime.Object, namespace string) error {
 				if err != nil {
 					return errors.Wrap(err, "Unable to decode item's raw field")
 				}
-				updateNamespace(&o, namespace)
+				if err = updateNamespace(&o, namespace); err != nil {
+					return err
+				}
 				items[i] = o
 			} else {
-				updateNamespace(&item, namespace)
+				if err = updateNamespace(&item, namespace); err != nil {
+					return err
+				}
 				items[i] = item
 			}
 		}
-		err = meta.SetList(*obj, items)
-		if err != nil {
-			errors.Wrap(err, "Unable to set items on List resource")
+		if err = meta.SetList(*obj, items); err != nil {
+			return errors.Wrap(err, "Unable to set items on List resource")
 		}
 	}
 	return nil

--- a/pkg/utilities/manifest/manifest.go
+++ b/pkg/utilities/manifest/manifest.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"reflect"
 	"strings"
-	"sync"
 
 	"github.com/pkg/errors"
 	bmv1alpha3 "github.com/weaveworks/wksctl/pkg/baremetal/v1alpha3"
@@ -20,8 +19,6 @@ import (
 	clusterv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	"sigs.k8s.io/yaml"
 )
-
-var mutex *sync.Mutex = &sync.Mutex{}
 
 // cluster-api types
 const (

--- a/pkg/utilities/version/version.go
+++ b/pkg/utilities/version/version.go
@@ -1,12 +1,9 @@
 package version
 
 import (
-	"fmt"
-	"strconv"
-	"strings"
-
 	"github.com/blang/semver"
 	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/util/version"
 )
 
 const (
@@ -34,16 +31,6 @@ func MatchesRange(version, versionsRange string) (bool, error) {
 	return r(v), nil
 }
 
-// MustMatchRange delegates to MatchesRange but panics on error instead of
-// returning the error.
-func MustMatchRange(version, versionsRange string) bool {
-	matches, err := MatchesRange(version, versionsRange)
-	if err != nil {
-		panic(err)
-	}
-	return matches
-}
-
 func Jump(nodeVersion, machineVersion string) (bool, error) {
 	nodemajor, nodeminor, _, err := parseVersion(nodeVersion)
 	if err != nil {
@@ -56,33 +43,22 @@ func Jump(nodeVersion, machineVersion string) (bool, error) {
 	return machinemajor == nodemajor && machineminor-nodeminor > 1, nil
 }
 
-func LessThan(v1, v2 string) (bool, error) {
-	v1major, v1minor, v1patch, err := parseVersion(v1)
+func LessThan(s1, s2 string) (bool, error) {
+	v1, err := version.ParseSemantic(s1)
 	if err != nil {
 		return false, err
 	}
-	v2major, v2minor, v2patch, err := parseVersion(v2)
+	v2, err := version.ParseSemantic(s2)
 	if err != nil {
 		return false, err
 	}
-	return (v1major < v2major) ||
-		(v1major == v2major && v1minor < v2minor) ||
-		(v1major == v2major && v1minor == v2minor && v1patch < v2patch), nil
+	return v1.LessThan(v2), nil
 }
 
-func parseVersion(v string) (int, int, int, error) {
-	v = strings.TrimPrefix(v, "v") // drop "v" at front
-	chunks := strings.Split(v, ".")
-	if len(chunks) != 3 { // major.minor.patch
-		return -1, -1, -1, fmt.Errorf("Invalid kubernetes version: %s", v)
+func parseVersion(s string) (int, int, int, error) {
+	v, err := version.ParseSemantic(s)
+	if err != nil {
+		return -1, -1, -1, errors.Wrap(err, "invalid kubernetes version")
 	}
-	var results = []int{-1, -1, -1}
-	for idx, item := range chunks {
-		val, err := strconv.Atoi(item)
-		if err != nil {
-			return -1, -1, -1, errors.Wrapf(err, "version is invalid")
-		}
-		results[idx] = val
-	}
-	return results[0], results[1], results[2], nil
+	return int(v.Major()), int(v.Minor()), int(v.Patch()), nil
 }

--- a/pkg/utilities/version/version.go
+++ b/pkg/utilities/version/version.go
@@ -71,11 +71,9 @@ func LessThan(v1, v2 string) (bool, error) {
 }
 
 func parseVersion(v string) (int, int, int, error) {
-	if strings.HasPrefix(v, "v") {
-		v = v[1:]
-	}
-	chunks := strings.Split(v, ".") // drop "v" at front
-	if len(chunks) != 3 {           // major.minor.patch
+	v = strings.TrimPrefix(v, "v") // drop "v" at front
+	chunks := strings.Split(v, ".")
+	if len(chunks) != 3 { // major.minor.patch
 		return -1, -1, -1, fmt.Errorf("Invalid kubernetes version: %s", v)
 	}
 	var results = []int{-1, -1, -1}

--- a/test/container/testutils/test_utils.go
+++ b/test/container/testutils/test_utils.go
@@ -152,7 +152,8 @@ func (r *FootlooseRunner) Start() error {
 
 	r.ssh, err = r.makeSSHClientWithRetries(30)
 	if err != nil {
-		r.cluster.Delete()
+		//nolint:errcheck
+		r.cluster.Delete() // TODO: Error handling
 		return err
 	}
 

--- a/test/integration/spawn/executor.go
+++ b/test/integration/spawn/executor.go
@@ -16,7 +16,6 @@ type stream int
 const (
 	stdout stream = 1 << 0
 	stderr stream = 1 << 1
-	all    stream = stderr | stdout
 )
 
 func (s stream) String() string {

--- a/test/integration/test/apply_test.go
+++ b/test/integration/test/apply_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes/scheme"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 )
@@ -332,25 +331,6 @@ func testNodes(t *testing.T, numMasters, numWorkers int) {
 	assert.Equal(t, numWorkers, nodesNumWorkers(nodes))
 }
 
-// DOES NOT CURRENTLY WORK - NODES DO NOT POSSESS THESE LABELS
-func testLabels(t *testing.T, numMasters, numWorkers int) {
-	test := kube.NewTest(t)
-	defer test.Close()
-
-	masterNodes := test.ListNodes(metav1.ListOptions{
-		LabelSelector: labels.Set(map[string]string{
-			"set": setLabel(master),
-		}).AsSelector().String(),
-	})
-	workerNodes := test.ListNodes(metav1.ListOptions{
-		LabelSelector: labels.Set(map[string]string{
-			"set": setLabel(node),
-		}).AsSelector().String(),
-	})
-	assert.Equal(t, numMasters, len(masterNodes.Items))
-	assert.Equal(t, numWorkers, len(workerNodes.Items))
-}
-
 func apply(exe *spawn.Executor, extra ...string) (*spawn.Entry, error) {
 	args := []string{"apply"}
 	args = append(args, extra...)
@@ -359,12 +339,6 @@ func apply(exe *spawn.Executor, extra ...string) (*spawn.Entry, error) {
 
 func kubeconfig(exe *spawn.Executor, extra ...string) (*spawn.Entry, error) {
 	args := []string{"kubeconfig"}
-	args = append(args, extra...)
-	return exe.RunV(cmd, args...)
-}
-
-func krb5Kubeconfig(exe *spawn.Executor, extra ...string) (*spawn.Entry, error) {
-	args := []string{"krb5-kubeconfig"}
 	args = append(args, extra...)
 	return exe.RunV(cmd, args...)
 }

--- a/test/integration/test/terraform.go
+++ b/test/integration/test/terraform.go
@@ -7,10 +7,8 @@ import (
 )
 
 const (
-	keyPrivateKeyPath = "private_key_path"
-	keyPublicIPs      = "public_ips"
-	keyPrivateIPs     = "private_ips"
-	keyUsername       = "username"
+	keyPublicIPs  = "public_ips"
+	keyPrivateIPs = "private_ips"
 )
 
 type terraformVariable struct {

--- a/tools/check-embedmd.sh
+++ b/tools/check-embedmd.sh
@@ -2,5 +2,5 @@
 
 for f in "$@"; do
     echo "embedmd: checking $f"
-    embedmd -d $f
+    embedmd -d "$f"
 done

--- a/tools/embedmd.sh
+++ b/tools/embedmd.sh
@@ -2,5 +2,5 @@
 
 for f in "$@"; do
     echo "embedmd: generating $f"
-    embedmd -w $f
+    embedmd -w "$f"
 done

--- a/tools/go-lint
+++ b/tools/go-lint
@@ -2,7 +2,7 @@
 
 set -e
 
-if [ ! $(command -v golangci-lint) ]
+if [ ! -x "$(command -v golangci-lint)" ]
 then
     go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.17.1
 fi

--- a/tools/go-lint
+++ b/tools/go-lint
@@ -4,7 +4,7 @@ set -e
 
 if [ ! -x "$(command -v golangci-lint)" ]
 then
-    go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.17.1
+    go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.27.0
 fi
 
 


### PR DESCRIPTION
Note the version of golangci-lint is updated, and a couple of things move directory.

This is #214 rebased on top of master now that #172 is merged. It adds a [golangci-lint](https://github.com/golangci/golangci-lint) GitHub Action for running the linter on pushes/pull requests and fixes most of the linter errors (unused functions etc.) The rest are marked `TODO` for decisions at a later date.