### PR TITLE
Move test cidr to avoid clashes

### DIFF
--- a/test/integration/container/multimaster_test.go
+++ b/test/integration/container/multimaster_test.go
@@ -28,7 +28,7 @@ spec:
     services:
       cidrBlocks: [10.96.0.0/12]
     pods:
-      cidrBlocks: [192.168.0.0/16]
+      cidrBlocks: [192.168.128.0/17]
     serviceDomain: cluster.local
   infrastructureRef:
     apiVersion: "cluster.weave.works/v1alpha3"

--- a/test/integration/test/apply_test.go
+++ b/test/integration/test/apply_test.go
@@ -254,9 +254,9 @@ func testCIDRBlocks(t *testing.T, kubeconfig string) {
 	podIP, err := cmd.CombinedOutput()
 	log.Printf("wks-controller has IP: %s\n", string(podIP))
 	assert.NoError(t, err)
-	isValid, err := assertIPisWithinRange(string(podIP), "192.168.0.0/16")
+	isValid, err := assertIPisWithinRange(string(podIP), "192.168.128.0/17")
 	assert.NoError(t, err)
-	log.Printf("Pod IP %s is inside 192.168.0.0/16 range? %v\n", podIP, isValid)
+	log.Printf("Pod IP %s is inside 192.168.127.0/17 range? %v\n", podIP, isValid)
 	assert.True(t, isValid)
 
 	cmdItems = []string{kubectl,

--- a/test/integration/test/assets/cluster.yaml
+++ b/test/integration/test/assets/cluster.yaml
@@ -7,7 +7,7 @@ spec:
       services:
           cidrBlocks: ["172.20.0.0/23"]
       pods:
-          cidrBlocks: ["192.168.0.0/16"]
+          cidrBlocks: ["192.168.128.0/17"]
       serviceDomain: "cluster.local"
   infrastructureRef:
       apiVersion: "cluster.weave.works/v1alpha3"


### PR DESCRIPTION
My home router uses 192.168.0.1 as the gateway and DNS server;
I believe this is a very popular choice.

Move wksctl tests to a range that doesn't cover this address.