### PR TITLE
Refactor auth sealed secret reading

### DIFF
--- a/pkg/apis/wksprovider/controller/wksctl/machine_controller.go
+++ b/pkg/apis/wksprovider/controller/wksctl/machine_controller.go
@@ -22,6 +22,7 @@ import (
 	"github.com/weaveworks/wksctl/pkg/kubernetes/drain"
 	"github.com/weaveworks/wksctl/pkg/plan"
 	"github.com/weaveworks/wksctl/pkg/plan/recipe"
+	"github.com/weaveworks/wksctl/pkg/plan/resource"
 	"github.com/weaveworks/wksctl/pkg/plan/runners/ssh"
 	"github.com/weaveworks/wksctl/pkg/specs"
 	bootstraputils "github.com/weaveworks/wksctl/pkg/utilities/kubeadm"
@@ -600,7 +601,7 @@ func (a *MachineController) getNodePlan(provider *baremetalspecv1.BareMetalClust
 	if err != nil {
 		return nil, err
 	}
-	var authSecrets map[string]map[string][]byte
+	var authSecrets map[string]resource.SecretData
 	if authConfigMap != nil {
 		authSecrets, err = a.getAuthSecrets(authConfigMap)
 		if err != nil {
@@ -648,8 +649,8 @@ func (a *MachineController) getAuthConfigMap() (*v1.ConfigMap, error) {
 	return nil, nil
 }
 
-func (a *MachineController) getAuthSecrets(authConfigMap *v1.ConfigMap) (map[string]map[string][]byte, error) {
-	authSecrets := map[string]map[string][]byte{}
+func (a *MachineController) getAuthSecrets(authConfigMap *v1.ConfigMap) (map[string]resource.SecretData, error) {
+	authSecrets := map[string]resource.SecretData{}
 	for _, authType := range []string{"authentication", "authorization"} {
 		secretName := authConfigMap.Data[authType+"-secret-name"]
 		client := a.clientSet.CoreV1().Secrets(a.controllerNamespace)

--- a/pkg/apis/wksprovider/machine/os/os.go
+++ b/pkg/apis/wksprovider/machine/os/os.go
@@ -575,7 +575,7 @@ func addClusterAPICRDs(b *plan.Builder) ([]string, error) {
 }
 
 func (o OS) seedNodeSetupPlan(params SeedNodeParams, providerSpec *baremetalspecv1.BareMetalClusterSpec, providerConfigMaps map[string]*v1.ConfigMap, authConfigMap *v1.ConfigMap, secretResources map[string]*secretResourceSpec, kubernetesVersion, kubernetesNamespace string) (*plan.Plan, error) {
-	secrets := map[string]map[string][]byte{}
+	secrets := map[string]resource.SecretData{}
 	for k, v := range secretResources {
 		secrets[k] = v.decrypted
 	}
@@ -699,7 +699,7 @@ func getConfigFileContents(fileNameComponent ...string) ([]byte, error) {
 
 type secretResourceSpec struct {
 	secretName string
-	decrypted  map[string][]byte
+	decrypted  resource.SecretData
 	resource   plan.Resource
 }
 
@@ -1111,7 +1111,7 @@ type NodeParams struct {
 	ConfigFileSpecs          []baremetalspecv1.FileSpec
 	ProviderConfigMaps       map[string]*v1.ConfigMap
 	AuthConfigMap            *v1.ConfigMap
-	Secrets                  map[string]map[string][]byte // type of auth -> names/values as-in v1.Secret
+	Secrets                  map[string]resource.SecretData // kind of auth -> names/values as-in v1.Secret
 	Namespace                string
 	ControlPlaneEndpoint     string // used instead of MasterIP if existed
 	AddonNamespaces          map[string]string
@@ -1198,7 +1198,7 @@ func (o OS) CreateNodeSetupPlan(params NodeParams) (*plan.Plan, error) {
 	return createPlan(b)
 }
 
-func addAuthConfigResources(b *plan.Builder, authConfigMap *v1.ConfigMap, secretData map[string][]byte, authType string) error {
+func addAuthConfigResources(b *plan.Builder, authConfigMap *v1.ConfigMap, secretData resource.SecretData, authType string) error {
 	secretName := authConfigMap.Data[authType+"-secret-name"]
 	if secretName != "" {
 		authPemRsrc, err := resource.NewKubeSecretResource(secretName, secretData, filepath.Join(PemDestDir, secretName),

--- a/pkg/plan/resource/kube_secret.go
+++ b/pkg/plan/resource/kube_secret.go
@@ -22,10 +22,13 @@ type KubeSecret struct {
 	// DestinationDirectory is the location in which to write stored file data
 	DestinationDirectory string `structs:"destinationDirectory"`
 	// SecretData holds the actual secret contents -- not serialized
-	SecretData map[string][]byte `structs:"-" plan:"hide"`
+	SecretData SecretData `structs:"-" plan:"hide"`
 	// FileNameTransform transforms a secret key into the file name for its contents
 	FileNameTransform func(string) string
 }
+
+// SecretData maps names to values as in Kubernetes v1.Secret
+type SecretData map[string][]byte
 
 var (
 	_ plan.Resource = plan.RegisterResource(&KubeSecret{})
@@ -41,7 +44,7 @@ func flattenMap(m map[string][]byte) []byte {
 }
 
 // NewKubeSecretResource creates a new object from secret data
-func NewKubeSecretResource(secretName string, secretData map[string][]byte, destinationDirectory string, fileNameTransform func(string) string) (*KubeSecret, error) {
+func NewKubeSecretResource(secretName string, secretData SecretData, destinationDirectory string, fileNameTransform func(string) string) (*KubeSecret, error) {
 	return &KubeSecret{
 		SecretName:           secretName,
 		Checksum:             sha256.Sum256(flattenMap(secretData)),

--- a/pkg/plan/resource/kube_secret.go
+++ b/pkg/plan/resource/kube_secret.go
@@ -7,18 +7,11 @@ import (
 	"sort"
 	"strings"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/weaveworks/wksctl/pkg/apis/wksprovider/machine/scripts"
 	"github.com/weaveworks/wksctl/pkg/plan"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 )
 
-// KubeSecret is a resource that reads a value out of a secret and writes it to the filesystem. It
-// can only be created when running in code deployed within the cluster because we want to store the
-// hash of the secret data in the Resource before the Plan is run so we can compare it against a later
-// version of the Plan when the secret is updated.
+// KubeSecret writes secrets to the filesystem where they can be picked up by daemons
 type KubeSecret struct {
 	base
 
@@ -47,26 +40,13 @@ func flattenMap(m map[string][]byte) []byte {
 	return []byte(strings.Join(items, ","))
 }
 
-func NewKubeSecretResource(secretName, destinationDirectory, ns string, fileNameTransform func(string) string) (*KubeSecret, error) {
-	config, err := rest.InClusterConfig()
-	if err != nil {
-		return nil, err
-	}
-	clientSet, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		log.Fatalf("failed to create Kubernetes client set: %v", err)
-	}
-	client := clientSet.CoreV1().Secrets(ns)
-	secret, err := client.Get(secretName, metav1.GetOptions{})
-	if err != nil {
-		// No secret present
-		return nil, nil
-	}
+// NewKubeSecretResource creates a new object from secret data
+func NewKubeSecretResource(secretName string, secretData map[string][]byte, destinationDirectory string, fileNameTransform func(string) string) (*KubeSecret, error) {
 	return &KubeSecret{
 		SecretName:           secretName,
-		Checksum:             sha256.Sum256(flattenMap(secret.Data)),
+		Checksum:             sha256.Sum256(flattenMap(secretData)),
 		DestinationDirectory: destinationDirectory,
-		SecretData:           secret.Data,
+		SecretData:           secretData,
 		FileNameTransform:    fileNameTransform,
 	}, nil
 }

--- a/test/integration/spawn/executor.go
+++ b/test/integration/spawn/executor.go
@@ -173,9 +173,6 @@ func (e *Executor) RunCmd(cmd *exec.Cmd) (*Entry, error) {
 		}
 	}
 
-	<-syncChan
-	<-syncChan
-
 	err = cmd.Wait()
 	exitCode, err := exitCode(err)
 	entry.exitCode = exitCode


### PR DESCRIPTION
The change in f93f1763ffd62a3a8a00b406d5b14b3ab8947bb1 to create the seed node plan at the time that node is set up had a flaw: the code was still trying to read sealed secrets from Kubernetes (which isn't up yet when creating the seed node).
This error was ignored, which was fixed in #242, so now all the CI tests using sealed secrets fail.

Refactor all code dealing with sealed secrets so that the plan resources can be created when the seed node is set up.
This does mean we pass around the decrypted secret in memory a bit more, which may be a concern.

Also remove erroneous chan receives left over by mistake in https://github.com/weaveworks/wksctl/pull/242