### PR TITLE
Compare node plans via json

### DIFF
--- a/pkg/apis/wksprovider/controller/wksctl/machine_controller.go
+++ b/pkg/apis/wksprovider/controller/wksctl/machine_controller.go
@@ -434,7 +434,10 @@ func (a *MachineController) update(ctx context.Context, c *baremetalspecv1.BareM
 	if err != nil {
 		return gerrors.Wrapf(err, "Failed to parse node plan for machine %s", machine.Name)
 	}
-	if currentState.Equal(planState) {
+	// check equality by re-serialising to JSON; this avoids any formatting differences, also
+	// type differences between deserialised State and State created from Plan.
+	planJSON := planState.ToJSON()
+	if currentState.ToJSON() == planJSON {
 		contextLog.Info("Machine and node have matching plans; nothing to do")
 		return nil
 	}
@@ -453,7 +456,6 @@ func (a *MachineController) update(ctx context.Context, c *baremetalspecv1.BareM
 			return err
 		}
 	}
-	planJSON := nodePlan.ToJSON()
 	upOrDowngrade := isUpOrDowngrade(machine, node)
 	contextLog.Infof("Is master: %t, is up or downgrade: %t", isMaster, upOrDowngrade)
 	if upOrDowngrade {

--- a/pkg/plan/state.go
+++ b/pkg/plan/state.go
@@ -23,6 +23,12 @@ func NewState() State {
 	return make(map[string]interface{})
 }
 
+// ToJSON serialises a State into JSON
+func (s State) ToJSON() string {
+	json, _ := json.Marshal(s)
+	return string(json)
+}
+
 // NewStateFromJSON creates State from JSON.
 func NewStateFromJSON(r io.Reader) (State, error) {
 	p := NewState()
@@ -131,6 +137,7 @@ func (s State) IsEmpty() bool {
 }
 
 // Equal returns true if two States are equal.
+// Note that State deserialised from JSON can contain map types which do not compare equal.
 func (s State) Equal(other State) bool {
 	return reflect.DeepEqual(s, other)
 }


### PR DESCRIPTION
There are ugly type differences when we do it using State objects.

(The symptom of the problem I am trying to fix is that wksctl-controller reinstalls the first node, but this does not show up in our tests.)