### PR TITLE
Fetch machine identity fewer times

### DIFF
--- a/pkg/apis/wksprovider/machine/os/os.go
+++ b/pkg/apis/wksprovider/machine/os/os.go
@@ -27,7 +27,6 @@ import (
 	"github.com/weaveworks/wksctl/pkg/plan"
 	"github.com/weaveworks/wksctl/pkg/plan/recipe"
 	"github.com/weaveworks/wksctl/pkg/plan/resource"
-	"github.com/weaveworks/wksctl/pkg/plan/runners/ssh"
 	"github.com/weaveworks/wksctl/pkg/plan/runners/sudo"
 	"github.com/weaveworks/wksctl/pkg/specs"
 	"github.com/weaveworks/wksctl/pkg/utilities/envcfg"
@@ -1213,7 +1212,7 @@ const (
 
 // Identify uses the provided SSH client to identify the operating system of
 // the machine it is configured to talk to.
-func Identify(sshClient *ssh.Client) (*OS, error) {
+func Identify(sshClient plan.Runner) (*OS, error) {
 	osID, err := fetchOSID(sshClient)
 	if err != nil {
 		return nil, err
@@ -1237,7 +1236,7 @@ const (
 	idxOSID            = 1
 )
 
-func fetchOSID(sshClient *ssh.Client) (string, error) {
+func fetchOSID(sshClient plan.Runner) (string, error) {
 	stdOut, err := sshClient.RunCommand("cat /etc/*release", nil)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to fetch operating system ID")

--- a/pkg/apis/wksprovider/machine/os/os.go
+++ b/pkg/apis/wksprovider/machine/os/os.go
@@ -81,7 +81,7 @@ type Identifiers struct {
 	SystemUUID string
 }
 
-// IDs returns this machine's ID system UUID.
+// IDs returns this machine's ID and system UUID.
 func (o OS) IDs() (*Identifiers, error) {
 	osres, err := resource.NewOS(o.runner)
 	if err != nil {

--- a/pkg/apis/wksprovider/machine/os/os.go
+++ b/pkg/apis/wksprovider/machine/os/os.go
@@ -82,22 +82,13 @@ type Identifiers struct {
 	SystemUUID string
 }
 
-// IDs returns this machine's ID (see also OS#GetMachineID) and system UUID (see
-// also: OS#GetSystemUUID).
+// IDs returns this machine's ID system UUID.
 func (o OS) IDs() (*Identifiers, error) {
 	osres, err := resource.NewOS(o.runner)
 	if err != nil {
 		return nil, err
 	}
-	machineID, err := osres.GetMachineID(o.runner)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to read machine's ID")
-	}
-	systemUUID, err := osres.GetSystemUUID(o.runner)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to read machine's system UUID")
-	}
-	return &Identifiers{MachineID: machineID, SystemUUID: systemUUID}, nil
+	return &Identifiers{MachineID: osres.MachineID, SystemUUID: osres.SystemUUID}, nil
 }
 
 type crdFile struct {

--- a/pkg/utilities/envcfg/envcfg_test.go
+++ b/pkg/utilities/envcfg/envcfg_test.go
@@ -259,22 +259,6 @@ func TestGetEnvSpecificConfig(t *testing.T) {
 			wantNamespace:            "foo",
 		},
 		{
-			name:    "os-release error",
-			pkgType: resource.PkgTypeRPM,
-			runner: &fakeRunner{
-				value: map[string]runnerResult{
-					cmdOsRel:             {out: relUbuntu, err: errors.New("kaboom")},
-					cmdEnv:               {},
-					cmdSELinuxFound:      {},
-					cmdMachineID:         {out: "01234567"},
-					cmdUUID:              {out: "01234567"},
-					cmdSELinuxPermissive: {},
-					cmdSELinuxEnforcing:  {},
-				},
-			},
-			wantError: true,
-		},
-		{
 			name:    "environ error",
 			pkgType: resource.PkgTypeRPM,
 			runner: &fakeRunner{

--- a/test/container/resource/os_test.go
+++ b/test/container/resource/os_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/weaveworks/wksctl/pkg/apis/wksprovider/machine/os"
 	"github.com/weaveworks/wksctl/pkg/plan"
 	"github.com/weaveworks/wksctl/pkg/plan/resource"
 	"github.com/weaveworks/wksctl/test/container/images"
@@ -19,14 +20,16 @@ func TestOS(t *testing.T) {
 	r, closer := NewRunnerForTest(t, images.CentOS7)
 	defer closer()
 
-	os := &resource.OS{}
+	os, err := os.Identify(r.Runner)
+	assert.NoError(t, err)
+
+	resOs := &resource.OS{}
 	// os.apply shoud force a query and update of state.
 	emptyDiff := plan.EmptyDiff()
-	_, err := os.Apply(r, emptyDiff)
+	_, err = resOs.Apply(r, emptyDiff)
 
 	assert.NoError(t, err)
 	assert.Equal(t, "centos", os.Name)
-	assert.Equal(t, "7", os.Version)
-	assert.Regexp(t, machineidRegexp, os.MachineID)
-	assert.Regexp(t, uuidRegexp, os.SystemUUID)
+	assert.Regexp(t, machineidRegexp, resOs.MachineID)
+	assert.Regexp(t, uuidRegexp, resOs.SystemUUID)
 }


### PR DESCRIPTION
`resource.OS` was fetching `Name` and `Version` which were never used.
`os.OS.IDs()` was fetching UUIDs again, even though they had just been fetched.
Remove the code that implemented this, and a test that relied on it.