### PR TITLE
Ensure two control-plane nodes remain up while we do an update

### DIFF
--- a/pkg/apis/wksprovider/controller/wksctl/machine_actuator.go
+++ b/pkg/apis/wksprovider/controller/wksctl/machine_actuator.go
@@ -950,12 +950,12 @@ func (a *MachineActuator) checkMasterHAConstraint() error {
 	for _, node := range nodes {
 		if hasConditionTrue(node, corev1.NodeReady) && !hasTaint(node, "NoSchedule") {
 			avail++
-			if avail >= 2 {
+			if avail > 2 { // We need 2 remaining after we take one offline
 				return nil
 			}
 		}
 	}
-	return errors.New("Fewer than two master nodes available")
+	return errors.New("Fewer than two control-plane nodes would be available")
 }
 
 func hasConditionTrue(node *corev1.Node, typ corev1.NodeConditionType) bool {


### PR DESCRIPTION
Cherry-pick of #274 to `release-0.8` branch