### PR TITLE
Move marking an updating node earlier so we can catch ssh errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	golang.org/x/crypto v0.0.0-20190617133340-57b3e21c3d56
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.0.1 // indirect
+    google.golang.org/appengine v1.4.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/oleiade/reflections.v1 v1.0.0
 	gopkg.in/src-d/go-git.v4 v4.10.0

--- a/pkg/apis/wksprovider/controller/wksctl/machine_actuator.go
+++ b/pkg/apis/wksprovider/controller/wksctl/machine_actuator.go
@@ -1070,7 +1070,7 @@ func (a *MachineActuator) exists(ctx context.Context, cluster *clusterv1.Cluster
 			return true, nil
 		}
 		count, e := a.getUpdateCount(node)
-		fmt.Printf("Update count for %s incremented to: %d, ERR: %v\n", node.Name, count, e)
+		contextLog.Infof("Update count for %s incremented to: %d, ERR: %v\n", node.Name, count, e)
 	}
 	os, closer, err := a.connectTo(machine, c, m)
 	if err != nil {
@@ -1127,7 +1127,6 @@ func (a *MachineActuator) incUpdateCount(node *corev1.Node) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	fmt.Printf("Update count for: %s = %d\n", node.Name, count)
 	switch count {
 	case 0:
 		return false, a.setNodeAnnotation(node, updateCountKey, "1")

--- a/pkg/apis/wksprovider/controller/wksctl/machine_actuator.go
+++ b/pkg/apis/wksprovider/controller/wksctl/machine_actuator.go
@@ -54,7 +54,7 @@ import (
 
 const (
 	planKey             string = "wks.weave.works/node-plan"
-	updateCountKey      string = "wks.weave.works/upgrade-count"
+	updateCountKey      string = "wks.weave.works/update-count"
 	maxUpgradeAttempts  int    = 5
 	masterLabel         string = "node-role.kubernetes.io/master"
 	originalMasterLabel string = "wks.weave.works/original-master"
@@ -506,6 +506,9 @@ func (a *MachineActuator) update(ctx context.Context, cluster *clusterv1.Cluster
 	currentPlan := node.Annotations[planKey]
 	if currentPlan == planJSON {
 		contextLog.Info("Machine and node have matching plans; nothing to do")
+		if err = a.setNodeAnnotation(node, updateCountKey, ""); err != nil {
+			return err
+		}
 		return nil
 	}
 


### PR DESCRIPTION
We need to mark a node before connecting so we can consider it failed after max retries rather than continuing.