### PR TITLE
Ignore kubectl error during multimaster test

### DIFF
--- a/test/integration/container/multimaster_test.go
+++ b/test/integration/container/multimaster_test.go
@@ -429,7 +429,11 @@ func TestMultimasterSetup(t *testing.T) {
 
 			var nodeList corev1.NodeList
 			for {
-				jsonOut := run(t, "kubectl", "get", "nodes", "-o", "json", fmt.Sprintf("--kubeconfig=%s", kubeconfig(out)))
+				jsonOut, stderr := doRun("kubectl", "get", "nodes", "-o", "json", fmt.Sprintf("--kubeconfig=%s", kubeconfig(out)))
+				if stderr != "" {
+					log.Warnf("error from kubectl; ignoring: %s", stderr)
+					continue
+				}
 				if err := json.Unmarshal([]byte(jsonOut), &nodeList); err != nil {
 					log.Warnf("Error deserialising output of kubectl get nodes: %s", err)
 				}


### PR DESCRIPTION
Fixes #237 

We often get "etcdserver: leader changed" responses from kubectl, which can be ignored.
Rather than special write special code for that one error, just log and ignore all errors on 'kubectl get nodes'.
