### PR TITLE
Annotate seed node via file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.6.1
 	github.com/thanhpk/randstr v1.0.4
-	github.com/weaveworks/cluster-api-provider-existinginfra v0.0.3
+	github.com/weaveworks/cluster-api-provider-existinginfra v0.0.4-0.20201019151825-abde7d1650ca
 	github.com/weaveworks/footloose v0.0.0-20200609124411-8f3df89ea188
 	github.com/weaveworks/go-checkpoint v0.0.0-20170503165305-ebbb8b0518ab
 	github.com/weaveworks/launcher v0.0.0-20180824102238-59a4fcc32c9c

--- a/go.sum
+++ b/go.sum
@@ -799,6 +799,8 @@ github.com/weaveworks/cluster-api-provider-existinginfra v0.0.2 h1:Z/OUvMxnX4Kjy
 github.com/weaveworks/cluster-api-provider-existinginfra v0.0.2/go.mod h1:1+bY5QfDcvqYDHCLF7a57X+/Zt3OSqyL/x7wayf+Wbo=
 github.com/weaveworks/cluster-api-provider-existinginfra v0.0.3 h1:kOACHKpyeJYFPQ4pk0TlHLkrswAtREuPI0+6XC6yCVM=
 github.com/weaveworks/cluster-api-provider-existinginfra v0.0.3/go.mod h1:1+bY5QfDcvqYDHCLF7a57X+/Zt3OSqyL/x7wayf+Wbo=
+github.com/weaveworks/cluster-api-provider-existinginfra v0.0.4-0.20201019151825-abde7d1650ca h1:HdYzEPKXEtm2USHNAqQ08DuoFbNpyaayaYiOvkFjTl8=
+github.com/weaveworks/cluster-api-provider-existinginfra v0.0.4-0.20201019151825-abde7d1650ca/go.mod h1:cXfxwXYmVybouksAJn3ftDNwYQ5RYG3cTVEKPYb9DGk=
 github.com/weaveworks/footloose v0.0.0-20200609124411-8f3df89ea188 h1:BuiVM+91YRjWUSMvF93A7Sm7s7IHrxjrPcc/5boO2V0=
 github.com/weaveworks/footloose v0.0.0-20200609124411-8f3df89ea188/go.mod h1:nxDdCjg1kb5+luh4mUCp+mtBZIWrhzoLIArrD99y+Sc=
 github.com/weaveworks/go-checkpoint v0.0.0-20170503165305-ebbb8b0518ab h1:mW+hgchD9qUUBqnuaDBj7BkcpFPk/FxeFcUFI5lvvUw=

--- a/pkg/plan/resource/kubeadm_init.go
+++ b/pkg/plan/resource/kubeadm_init.go
@@ -10,7 +10,6 @@ import (
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/weaveworks/cluster-api-provider-existinginfra/pkg/apis/wksprovider/machine/config"
-	"github.com/weaveworks/cluster-api-provider-existinginfra/pkg/apis/wksprovider/machine/scripts"
 	capeiplan "github.com/weaveworks/cluster-api-provider-existinginfra/pkg/plan"
 	capeiresource "github.com/weaveworks/cluster-api-provider-existinginfra/pkg/plan/resource"
 	capeimanifest "github.com/weaveworks/cluster-api-provider-existinginfra/pkg/utilities/manifest"
@@ -141,7 +140,7 @@ func (ki *KubeadmInit) Apply(ctx context.Context, runner capeiplan.Runner, diff 
 	configBytes := buf.Bytes()
 
 	remotePath := "/tmp/wks_kubeadm_init_config.yaml"
-	if err = scripts.WriteFile(ctx, configBytes, remotePath, 0660, runner); err != nil {
+	if err = capeiresource.WriteFile(ctx, configBytes, remotePath, 0660, runner); err != nil {
 		return false, errors.Wrap(err, "failed to upload kubeadm's configuration")
 	}
 	log.WithField("yaml", string(configBytes)).Debug("uploaded kubeadm's configuration")

--- a/pkg/plan/resource/kubectl_apply.go
+++ b/pkg/plan/resource/kubectl_apply.go
@@ -9,9 +9,9 @@ import (
 
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
-	"github.com/weaveworks/cluster-api-provider-existinginfra/pkg/apis/wksprovider/machine/scripts"
 	"github.com/weaveworks/cluster-api-provider-existinginfra/pkg/plan"
 	"github.com/weaveworks/cluster-api-provider-existinginfra/pkg/plan/resource"
+	capeiresource "github.com/weaveworks/cluster-api-provider-existinginfra/pkg/plan/resource"
 	"github.com/weaveworks/cluster-api-provider-existinginfra/pkg/utilities/manifest"
 	"github.com/weaveworks/libgitops/pkg/serializer"
 )
@@ -94,7 +94,7 @@ func writeTempFile(ctx context.Context, r plan.Runner, c []byte, fname string) (
 	}
 	path := strings.Trim(pathDirty, "\n")
 
-	if err := scripts.WriteFile(ctx, c, path, 0660, r); err != nil {
+	if err := capeiresource.WriteFile(ctx, c, path, 0660, r); err != nil {
 		// Try to delete the temp file.
 		if _, rmErr := r.RunCommand(ctx, fmt.Sprintf("rm -vf %q", path), nil); rmErr != nil {
 			log.WithField("path", path).Errorf("failed to clean up the temp file: %v", rmErr)


### PR DESCRIPTION
We put the node plan on each node as an annotation.
The plan value can contain shell characters such as `'` and `!`, so put the contents in a file before calling `kubectl annotate`.

Interestingly there is no option in `kubectl` to take the value from a file, so we still have to `cat` it on the command-line.

This change is based on http://github.com/weaveworks/cluster-api-provider-existinginfra/pull/30, since I noticed `WriteFile()` was in a strange place.
