### PR TITLE
Update CAPEI and docker image in multimaster test to v0.0.9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.6.1
 	github.com/thanhpk/randstr v1.0.4
-	github.com/weaveworks/cluster-api-provider-existinginfra v0.0.8
+	github.com/weaveworks/cluster-api-provider-existinginfra v0.0.9
 	github.com/weaveworks/footloose v0.0.0-20200918140536-ff126705213e
 	github.com/weaveworks/go-checkpoint v0.0.0-20170503165305-ebbb8b0518ab
 	github.com/weaveworks/launcher v0.0.0-20180824102238-59a4fcc32c9c

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/weaveworks/launcher v0.0.0-20180824102238-59a4fcc32c9c
 	github.com/weaveworks/libgitops v0.0.2
 	github.com/whilp/git-urls v0.0.0-20191001220047-6db9661140c0
-	golang.org/x/crypto v0.0.0-20200707235045-ab33eee955e0
+	golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897
 	golang.org/x/tools v0.0.0-20200708003708-134513de8882 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.1.0 // indirect
 	google.golang.org/appengine v1.6.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -849,8 +849,8 @@ github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv
 github.com/vishvananda/netlink v1.0.0/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJqOg65H/2ktk=
 github.com/vishvananda/netns v0.0.0-20171111001504-be1fbeda1936/go.mod h1:ZjcWmFBXmLKZu9Nxj3WKYEafiSqer2rnvPr0en9UNpI=
 github.com/vmware/govmomi v0.20.3/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59bHWk6aFU=
-github.com/weaveworks/cluster-api-provider-existinginfra v0.0.8 h1:8huD4i0tFFg5+qt+TBQpiTPCsn/iDVb/ni3iqbNk9mo=
-github.com/weaveworks/cluster-api-provider-existinginfra v0.0.8/go.mod h1:9uXK1LB/rKlWSKu+tTKoT3JPqiOaVr+PG+kbWZyIBLg=
+github.com/weaveworks/cluster-api-provider-existinginfra v0.0.9 h1:fS9G1nAns5+15i8NNH5WLuCfIoAU1oMeAf0RWG2ekHg=
+github.com/weaveworks/cluster-api-provider-existinginfra v0.0.9/go.mod h1:YEi5vGmSucFgcmHl+mUIp8dfm4aX3UO5tuUzSoh5Pfs=
 github.com/weaveworks/footloose v0.0.0-20200918140536-ff126705213e h1:lW0k9X2U0S+6Kq5qoYQaDKrUCS50x2M7ZivVpOFgTso=
 github.com/weaveworks/footloose v0.0.0-20200918140536-ff126705213e/go.mod h1:nxDdCjg1kb5+luh4mUCp+mtBZIWrhzoLIArrD99y+Sc=
 github.com/weaveworks/go-checkpoint v0.0.0-20170503165305-ebbb8b0518ab h1:mW+hgchD9qUUBqnuaDBj7BkcpFPk/FxeFcUFI5lvvUw=
@@ -923,6 +923,8 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnk
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200707235045-ab33eee955e0 h1:eIYIE7EC5/Wv5Kbz8bJPaq+TN3kq3W8S+LSm62vM0DY=
 golang.org/x/crypto v0.0.0-20200707235045-ab33eee955e0/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897 h1:pLI5jrR7OSLijeIDcmRxNmw2api+jEfxLoykJVice/E=
+golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20180321215751-8460e604b9de/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20180807140117-3d87b88a115f/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=

--- a/pkg/apis/wksprovider/controller/manifests/yaml/04_controller.yaml
+++ b/pkg/apis/wksprovider/controller/manifests/yaml/04_controller.yaml
@@ -42,7 +42,7 @@ spec:
         operator: Exists
       containers:
       - name: controller
-        image: weaveworks/cluster-api-existinginfra-controller:v0.0.8
+        image: weaveworks/cluster-api-existinginfra-controller:v0.0.9
         args:
         - --verbose
         resources:

--- a/test/integration/container/multimaster_test.go
+++ b/test/integration/container/multimaster_test.go
@@ -373,7 +373,7 @@ func TestMultimasterSetup(t *testing.T) {
 		run(t, filepath.Join(rootDir, "environments/local-docker-registry/retag_push.sh"), "-p", strconv.Itoa(registryPort))
 	}
 	// FIXME: look this value up more dynamically.
-	const capeiImage = "weaveworks/cluster-api-existinginfra-controller:v0.0.8"
+	const capeiImage = "weaveworks/cluster-api-existinginfra-controller:v0.0.9"
 	run(t, "docker", "pull", capeiImage)
 	run(t, "docker", "tag", capeiImage, fmt.Sprintf("localhost:%d/%s", registryPort, capeiImage))
 	run(t, "docker", "push", fmt.Sprintf("localhost:%d/%s", registryPort, capeiImage))

--- a/test/integration/test/apply_test.go
+++ b/test/integration/test/apply_test.go
@@ -430,7 +430,7 @@ func TestApply(t *testing.T) {
 	// Install the Cluster.
 	run, err = apply(exe, "--cluster="+clusterManifestPath, "--machines="+machinesManifestPath,
 		"--config-directory="+configDir, "--sealed-secret-key="+configPath("ss.key"), "--sealed-secret-cert="+configPath("ss.cert"),
-		"--verbose=true", "--ssh-key="+sshKeyPath, "--controller-image=docker.io/weaveworks/cluster-api-existinginfra-controller:v0.0.8")
+		"--verbose=true", "--ssh-key="+sshKeyPath, "--controller-image=docker.io/weaveworks/cluster-api-existinginfra-controller:v0.0.9")
 	assert.NoError(t, err)
 	require.Equal(t, 0, run.ExitCode())
 


### PR DESCRIPTION
Updates CAPEI dependency in `go.mod` and docker image references to v0.0.9