### PR TITLE
Upgrades golint-ci for new github actions env changes

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v1
+        uses: golangci/golangci-lint-action@v2.3.0
         with:
           version: v1.30
           args: --timeout 5m


### PR DESCRIPTION
Github deprecated some env things:
- https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

New golangci-lint looks like it fixes this
- https://github.com/golangci/golangci-lint-action/issues/127#issuecomment-729139550