### PR TITLE
Stop running Weave Net in host PID namespace

### DIFF
--- a/addons/weave-net/weave-net.yaml
+++ b/addons/weave-net/weave-net.yaml
@@ -177,7 +177,7 @@ items:
                   readOnly: false
           hostNetwork: true
           dnsPolicy: ClusterFirstWithHostNet
-          hostPID: true
+          hostPID: false
           restartPolicy: Always
           securityContext:
             seLinuxOptions: {}

--- a/pkg/apis/wksprovider/machine/os/os_test.go
+++ b/pkg/apis/wksprovider/machine/os/os_test.go
@@ -265,7 +265,7 @@ items:
                 readOnly: false
         hostNetwork: true
         dnsPolicy: ClusterFirstWithHostNet
-        hostPID: true
+        hostPID: false
         restartPolicy: Always
         securityContext:
           seLinuxOptions: {}


### PR DESCRIPTION
We shouldn't need this.